### PR TITLE
feat(s3): Allow separate logging bucket for AWS Config

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/accelerator-resource-names.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/accelerator-resource-names.ts
@@ -73,6 +73,7 @@ interface BucketPrefixes {
   elbLogs: string;
   costUsage: string;
   s3AccessLogs: string;
+  awsConfig: string;
   auditManager: string;
   vpcFlowLogs: string;
   metadata: string;
@@ -137,6 +138,7 @@ export class AcceleratorResourceNames {
     elbLogs: 'PLACE_HOLDER',
     costUsage: 'PLACE_HOLDER',
     s3AccessLogs: 'PLACE_HOLDER',
+    awsConfig: 'PLACE_HOLDER',
     auditManager: 'PLACE_HOLDER',
     vpcFlowLogs: 'PLACE_HOLDER',
     metadata: 'PLACE_HOLDER',
@@ -256,6 +258,7 @@ export class AcceleratorResourceNames {
     this.bucketPrefixes.elbLogs = props.prefixes.bucketName + '-elb-access-logs';
     this.bucketPrefixes.costUsage = props.prefixes.bucketName + '-cur';
     this.bucketPrefixes.s3AccessLogs = props.prefixes.bucketName + '-s3-access-logs';
+    this.bucketPrefixes.awsConfig = props.prefixes.bucketName + '-aws-config';
     this.bucketPrefixes.auditManager = props.prefixes.bucketName + '-auditmgr';
     this.bucketPrefixes.vpcFlowLogs = props.prefixes.bucketName + '-vpc';
     this.bucketPrefixes.metadata = props.prefixes.bucketName + '-metadata';

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
@@ -544,7 +544,11 @@ export class SecurityResourcesStack extends AcceleratorStack {
         });
 
         this.deliveryChannel = new cdk.aws_config.CfnDeliveryChannel(this, 'ConfigDeliveryChannel', {
-          s3BucketName: `${this.acceleratorResourceNames.bucketPrefixes.centralLogs}-${this.logArchiveAccountId}-${this.props.centralizedLoggingRegion}`,
+          s3BucketName: `${
+            this.props.securityConfig.awsConfig.useSeparateBucket
+              ? this.acceleratorResourceNames.bucketPrefixes.awsConfig
+              : this.acceleratorResourceNames.bucketPrefixes.centralLogs
+          }-${this.logArchiveAccountId}-${this.props.centralizedLoggingRegion}`,
           configSnapshotDeliveryProperties: {
             deliveryFrequency: 'One_Hour',
           },
@@ -553,7 +557,11 @@ export class SecurityResourcesStack extends AcceleratorStack {
 
       if (this.props.securityConfig.awsConfig.overrideExisting) {
         const configServiceUpdater = new ConfigServiceRecorder(this, 'ConfigRecorderDeliveryChannel', {
-          s3BucketName: `${this.acceleratorResourceNames.bucketPrefixes.centralLogs}-${this.logArchiveAccountId}-${this.props.centralizedLoggingRegion}`,
+          s3BucketName: `${
+            this.props.securityConfig.awsConfig.useSeparateBucket
+              ? this.acceleratorResourceNames.bucketPrefixes.awsConfig
+              : this.acceleratorResourceNames.bucketPrefixes.centralLogs
+          }-${this.logArchiveAccountId}-${this.props.centralizedLoggingRegion}`,
           s3BucketKmsKey: this.centralLogS3Key,
           logRetentionInDays: this.props.globalConfig.cloudwatchLogRetentionInDays,
           configRecorderRoleArn: configRecorderRole.roleArn,

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
@@ -1022,6 +1022,338 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 1`] = `
       },
       "Type": "AWS::IAM::ServiceLinkedRole",
     },
+    "ConfigBucketCmkC7CFE158": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "EnableKeyRotation": true,
+        "KeyPolicy": {
+          "Statement": [
+            {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::333333333333:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ConfigBucketConfigBucketReplicationAwsAcceleratorCentralLogs333333333333UsWest2ReplicationRole9722BD80": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "s3.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/service-role/",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ConfigBucketConfigBucketReplicationAwsAcceleratorCentralLogs333333333333UsWest2ReplicationRoleDefaultPolicyE9501E79": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Allows only specific policy.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectRetention",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionForReplication",
+                "s3:GetObjectVersionTagging",
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ConfigBucketE7CC15D9",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ConfigBucketE7CC15D9",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetBucketVersioning",
+                "s3:GetObjectVersionTagging",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:PutBucketVersioning",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:ReplicateTags",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::aws-accelerator-central-logs-333333333333-us-west-2/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ConfigBucketCmkC7CFE158",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "kms:Encrypt",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AcceleratorCentralLogBucketKeyLookup26F8C418",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ConfigBucketConfigBucketReplicationAwsAcceleratorCentralLogs333333333333UsWest2ReplicationRoleDefaultPolicyE9501E79",
+        "Roles": [
+          {
+            "Ref": "ConfigBucketConfigBucketReplicationAwsAcceleratorCentralLogs333333333333UsWest2ReplicationRole9722BD80",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ConfigBucketConfigBucketReplicationB49EB5CE": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "CustomS3PutBucketReplicationCustomResourceProviderLogGroup6A67905E",
+      ],
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomS3PutBucketReplicationCustomResourceProviderHandler1D75398C",
+            "Arn",
+          ],
+        },
+        "destinationAccountId": "333333333333",
+        "destinationBucketArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":s3:::aws-accelerator-central-logs-333333333333-us-west-2",
+            ],
+          ],
+        },
+        "destinationBucketKeyArn": {
+          "Ref": "AcceleratorCentralLogBucketKeyLookup26F8C418",
+        },
+        "prefix": "",
+        "replicationRoleArn": {
+          "Fn::GetAtt": [
+            "ConfigBucketConfigBucketReplicationAwsAcceleratorCentralLogs333333333333UsWest2ReplicationRole9722BD80",
+            "Arn",
+          ],
+        },
+        "sourceBucketName": {
+          "Ref": "ConfigBucketE7CC15D9",
+        },
+      },
+      "Type": "Custom::S3PutBucketReplication",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ConfigBucketE7CC15D9": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": {
+                  "Fn::GetAtt": [
+                    "ConfigBucketCmkC7CFE158",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "BucketName": "aws-accelerator-aws-config-333333333333-us-east-1",
+        "LoggingConfiguration": {
+          "DestinationBucketName": {
+            "Ref": "AccessLogsBucketFA218D2A",
+          },
+          "LogFilePrefix": "aws-accelerator-aws-config-333333333333-us-east-1/",
+        },
+        "OwnershipControls": {
+          "Rules": [
+            {
+              "ObjectOwnership": "BucketOwnerPreferred",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ConfigBucketPolicy97E52C2B": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "ConfigBucketE7CC15D9",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*",
+              },
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ConfigBucketE7CC15D9",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ConfigBucketE7CC15D9",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "deny-insecure-connections",
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "StringEquals": {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "config.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "ConfigBucketE7CC15D9",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetBucketAcl",
+                "s3:ListBucket",
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "config.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "ConfigBucketE7CC15D9",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "CrossAccountCentralSnsTopicKMSArnSsmParamAccessRoleFA0EB249": {
       "Metadata": {
         "cdk_nag": {

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/security-resources-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/security-resources-stack.test.ts.snap
@@ -2764,7 +2764,7 @@ exports[`SecurityResourcesStack Construct(SecurityResourcesStack):  Snapshot Tes
         "ConfigSnapshotDeliveryProperties": {
           "DeliveryFrequency": "One_Hour",
         },
-        "S3BucketName": "aws-accelerator-central-logs-333333333333-us-west-2",
+        "S3BucketName": "aws-accelerator-aws-config-333333333333-us-west-2",
       },
       "Type": "AWS::Config::DeliveryChannel",
     },

--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/security-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/security-config.yaml
@@ -129,6 +129,7 @@ iamPasswordPolicy:
 awsConfig:
   enableConfigurationRecorder: true
   enableDeliveryChannel: true
+  useSeparateBucket: true
   ruleSets:
     - deploymentTargets:
         organizationalUnits:

--- a/source/packages/@aws-accelerator/config/lib/global-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/global-config.ts
@@ -82,6 +82,11 @@ export abstract class GlobalConfigTypes {
     kmsResourcePolicyAttachments: t.optional(t.array(t.resourcePolicyStatement)),
   });
 
+  static readonly configBucketConfig = t.interface({
+    lifecycleRules: t.array(t.lifecycleRuleConfig),
+    s3ResourcePolicyAttachments: t.optional(t.array(t.resourcePolicyStatement)),
+  });
+
   static readonly elbLogBucketConfig = t.interface({
     lifecycleRules: t.array(t.lifecycleRuleConfig),
     s3ResourcePolicyAttachments: t.optional(t.array(t.resourcePolicyStatement)),
@@ -603,6 +608,40 @@ export class CentralLogBucketConfig implements t.TypeOf<typeof GlobalConfigTypes
 }
 
 /**
+ * *{@link GlobalConfig} / {@link LoggingConfig} / {@link ConfigBucketConfig}*
+ *
+ * Accelerator global S3 config logging configuration
+ *
+ * @example
+ * ```
+ * configBucket:
+ *   lifecycleRules:
+ *     - enabled: true
+ *       id: ConfigLifecycle
+ *       abortIncompleteMultipartUpload: 14
+ *       expiration: 3563
+ *       expiredObjectDeleteMarker: true
+ *       noncurrentVersionExpiration: 3653
+ *       noncurrentVersionTransitions:
+ *         - storageClass: GLACIER
+ *           transitionAfter: 365
+ *       transitions:
+ *         - storageClass: GLACIER
+ *           transitionAfter: 365
+ *   s3ResourcePolicyAttachments:
+ *     - policy: s3-policies/policy1.json
+ * ```
+ */
+export class ConfigBucketConfig implements t.TypeOf<typeof GlobalConfigTypes.configBucketConfig> {
+  /**
+   * Declaration of (S3 Bucket) Lifecycle rules.
+   * Configure additional resource policy attachments
+   */
+  readonly lifecycleRules: t.LifeCycleRule[] = [];
+  readonly s3ResourcePolicyAttachments: t.ResourcePolicyStatement[] | undefined = undefined;
+}
+
+/**
  * *{@link GlobalConfig} / {@link LoggingConfig} / {@link ElbLogBucketConfig}*
  *
  * Accelerator global S3 elb logging configuration
@@ -783,6 +822,10 @@ export class LoggingConfig implements t.TypeOf<typeof GlobalConfigTypes.loggingC
    * Declaration of a (S3 Bucket) Lifecycle rule configuration.
    */
   readonly centralLogBucket: CentralLogBucketConfig | undefined = undefined;
+  /**
+   * Declaration of a (S3 Bucket) Lifecycle rule configuration.
+   */
+  readonly configBucket: ConfigBucketConfig | undefined = undefined;
   /**
    * Declaration of a (S3 Bucket) Lifecycle rule configuration.
    */

--- a/source/packages/@aws-accelerator/config/lib/security-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/security-config.ts
@@ -476,6 +476,7 @@ export class SecurityConfigTypes {
     enableDeliveryChannel: t.optional(t.boolean),
     overrideExisting: t.optional(t.boolean),
     aggregation: t.optional(this.awsConfigAggregation),
+    useSeparateBucket: t.optional(t.boolean),
     ruleSets: t.array(this.awsConfigRuleSet),
   });
 
@@ -1896,6 +1897,7 @@ export class AwsConfigRuleSet implements t.TypeOf<typeof SecurityConfigTypes.aws
  *   ** enableDeliveryChannel DEPRECATED
  *   enableDeliveryChannel: true
  *   overrideExisting: false
+ *   useSeparateBucket: false
  *   aggregation:
  *     enable: true
  *     delegatedAdminAccount: LogArchive
@@ -1941,6 +1943,12 @@ export class AwsConfig implements t.TypeOf<typeof SecurityConfigTypes.awsConfig>
    * iam permission for the iam role name {acceleratorPrefix}Config
    */
   readonly overrideExisting: boolean | undefined;
+  /**
+   * Indicates whether to create a separate bucket to point delivery channel at.
+   *
+   * AWS Config delivery channel will point to this bucket and have its contents then replicated to the central logs bucket. This enables the option to enable Object Lock on the central logs bucket and still receiving data from the delivery channel.
+   */
+  readonly useSeparateBucket = false;
   /**
    * Config Recorder Aggregation configuration
    */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For the case where the central logs bucket has Object Lock enabled, AWS Config does not support logging directly to the central logs bucket. A workaround for that issue is to create a separate bucket without Object Lock enabled and replicate everything over to the central logs bucket. This change adds the option to create that separate bucket with a replication rule into the central logs bucket and repointing AWS Config to use that separate bucket instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
