### PR TITLE
fix (account-stacks): scpRevertChanges should use accelerator prefix

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/accounts-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/accounts-stack.ts
@@ -266,6 +266,7 @@ export class AccountsStack extends AcceleratorStack {
         if (props.securityConfig.centralSecurityServices?.scpRevertChangesConfig?.enable) {
           this.logger.info(`Creating resources to revert modifications to scps`);
           new RevertScpChanges(this, 'RevertScpChanges', {
+            acceleratorPrefix: props.prefixes.accelerator,
             configDirPath: props.configDirPath,
             homeRegion: props.globalConfig.homeRegion,
             kmsKeyCloudWatch: this.cloudwatchKey,

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
@@ -1655,6 +1655,7 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
         "Description": "Lambda function to revert changes made to LZA-controlled service control policies",
         "Environment": {
           "Variables": {
+            "ACCELERATOR_PREFIX": "AWSAccelerator",
             "AWS_PARTITION": {
               "Ref": "AWS::Partition",
             },

--- a/source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes.ts
@@ -27,6 +27,10 @@ import * as path from 'path';
  */
 export interface RevertScpChangesProps {
   /**
+   * Audit account Id
+   */
+  readonly acceleratorPrefix: string;
+  /**
    * Configuration directory path
    */
   readonly configDirPath: string;
@@ -115,6 +119,7 @@ export class RevertScpChanges extends Construct {
       description: 'Lambda function to revert changes made to LZA-controlled service control policies',
       timeout: cdk.Duration.minutes(LAMBDA_TIMEOUT_IN_MINUTES),
       environment: {
+        ACCELERATOR_PREFIX: props.acceleratorPrefix,
         AWS_PARTITION: cdk.Aws.PARTITION,
         HOME_REGION: props.homeRegion,
         SNS_TOPIC_ARN: snsTopicArn ?? '',

--- a/source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes/index.ts
@@ -20,7 +20,7 @@ import { throttlingBackOff } from '@aws-accelerator/utils';
 
 let organizationsClient: AWS.Organizations;
 
-const acceleratorRolePrefix = 'AWSAccelerator';
+const acceleratorRolePrefix = process.env['ACCELERATOR_PREFIX'] ?? 'AWSAccelerator';
 const snsTopicArn = process.env['SNS_TOPIC_ARN'];
 const partition = process.env['AWS_PARTITION']!;
 const homeRegion = process.env['HOME_REGION']!;

--- a/source/packages/@aws-accelerator/constructs/test/aws-events/__snapshots__/revert-scp-changes.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-events/__snapshots__/revert-scp-changes.test.ts.snap
@@ -147,6 +147,7 @@ exports[`RevertScpChanges Construct(RevertScpChanges):  Snapshot Test 1`] = `
         "Description": "Lambda function to revert changes made to LZA-controlled service control policies",
         "Environment": {
           "Variables": {
+            "ACCELERATOR_PREFIX": "AWSAccelerator",
             "AWS_PARTITION": {
               "Ref": "AWS::Partition",
             },

--- a/source/packages/@aws-accelerator/constructs/test/aws-events/revert-scp-changes.test.ts
+++ b/source/packages/@aws-accelerator/constructs/test/aws-events/revert-scp-changes.test.ts
@@ -22,6 +22,7 @@ const stack = new cdk.Stack();
 const configDirPath = `${__dirname}/../../../accelerator/test/configs/all-enabled`;
 
 new RevertScpChanges(stack, 'RevertScpChanges', {
+  acceleratorPrefix: 'AWSAccelerator',
   configDirPath: configDirPath,
   homeRegion: 'us-west-2',
   kmsKeyCloudWatch: new cdk.aws_kms.Key(stack, 'CustomCloudWatchKey', {}),


### PR DESCRIPTION
*Issue #163 :*

*Description of changes:*
Modified  `source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes/index.ts` to use environment variable for accelerator prefix when testing if `isChangeMadeByAccelerator`.

Modified `source/packages/@aws-accelerator/accelerator/lib/stacks/accounts-stack.ts` and `source/packages/@aws-accelerator/constructs/lib/aws-events/revert-scp-changes.ts` to propagate the `AcceleratorPrefix` parameter from the CF template down the Lambda function.

Modified test cases accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
