### PR TITLE
chore(config): CCCS/TSE Config updates for SCP granular billing permissions

### DIFF
--- a/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Sandbox.json
+++ b/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Sandbox.json
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -133,7 +139,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -172,7 +177,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Sensitive.json
+++ b/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Sensitive.json
@@ -5,11 +5,11 @@
       "Sid": "PMP",
       "Effect": "Deny",
       "Action": [
-        "aws-marketplace:CreatePrivate*",
-        "aws-marketplace:AssociateProductsWithPrivate*",
-        "aws-marketplace:DescribePrivate*",
-        "aws-marketplace:DisassociateProducts*",
-        "aws-marketplace:ListPrivate*"
+        "aws-marketplace:As*",
+        "aws-marketplace:CreateP*",
+        "aws-marketplace:DescribePri*",
+        "aws-marketplace:Di*",
+        "aws-marketplace:ListP*"
       ],
       "Resource": "*"
     },
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -217,7 +223,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -260,7 +265,15 @@
         "s3:PutMultiR*",
         "sns:Publish",
         "tag:GetResources",
-        "sso:DescribeRegisteredRegions"
+        "sso:DescribeRegisteredRegions",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Unclass.json
+++ b/reference/sample-configurations/aws-best-practices-cccs-medium/config/service-control-policies/LZA-Guardrails-Unclass.json
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -197,7 +203,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -236,7 +241,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Sandbox.json
+++ b/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Sandbox.json
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -133,7 +139,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -172,7 +177,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Sensitive.json
+++ b/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Sensitive.json
@@ -5,11 +5,11 @@
       "Sid": "PMP",
       "Effect": "Deny",
       "Action": [
-        "aws-marketplace:CreatePrivate*",
-        "aws-marketplace:AssociateProductsWithPrivate*",
-        "aws-marketplace:DescribePrivate*",
-        "aws-marketplace:DisassociateProducts*",
-        "aws-marketplace:ListPrivate*"
+        "aws-marketplace:As*",
+        "aws-marketplace:CreateP*",
+        "aws-marketplace:DescribePri*",
+        "aws-marketplace:Di*",
+        "aws-marketplace:ListP*"
       ],
       "Resource": "*"
     },
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -217,7 +223,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -260,7 +265,15 @@
         "s3:PutMultiR*",
         "sns:Publish",
         "tag:GetResources",
-        "sso:DescribeRegisteredRegions"
+        "sso:DescribeRegisteredRegions",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Unclass.json
+++ b/reference/sample-configurations/aws-best-practices-tse-se/config/service-control-policies/LZA-Guardrails-Unclass.json
@@ -23,11 +23,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -102,9 +102,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -116,7 +114,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -197,7 +203,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -236,7 +241,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This change replaces the retired service prefix `aws-portal`, and replaces them with the new fine-grained service specific permissions. This retirement is described [here](https://aws.amazon.com/blogs/aws-cloud-financial-management/changes-to-aws-billing-cost-management-and-account-consoles-permissions/).

The changes affect these CCCS/TSE Service Control Policies:
* LZA-Guardrails-Sandbox.json
* LZA-Guardrails-Sensitive.json
* LZA-Guardrails-Unclass.json


