### PR TITLE
feat(bucketLifecycle): allow for prefix

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
@@ -530,6 +530,7 @@ export abstract class AcceleratorStack extends cdk.Stack {
         expiration: lifecycleRule.expiration,
         expiredObjectDeleteMarker: lifecycleRule.expiredObjectDeleteMarker,
         id: lifecycleRule.id,
+        prefix: lifecycleRule.prefix,
         noncurrentVersionExpiration: lifecycleRule.noncurrentVersionExpiration,
         noncurrentVersionTransitions,
         transitions,

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
@@ -1273,7 +1273,7 @@ export class LoggingStack extends AcceleratorStack {
         kmsKey: this.cloudwatchKey,
         logRetentionInDays: this.props.globalConfig.cloudwatchLogRetentionInDays,
       };
-
+      
       this.centralLogsBucket = new CentralLogsBucket(this, 'CentralLogsBucket', {
         s3BucketName: this.centralLogsBucketName,
         serverAccessLogsBucket: serverAccessLogsBucket,

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
@@ -1273,7 +1273,6 @@ export class LoggingStack extends AcceleratorStack {
         kmsKey: this.cloudwatchKey,
         logRetentionInDays: this.props.globalConfig.cloudwatchLogRetentionInDays,
       };
-      
       this.centralLogsBucket = new CentralLogsBucket(this, 'CentralLogsBucket', {
         s3BucketName: this.centralLogsBucketName,
         serverAccessLogsBucket: serverAccessLogsBucket,

--- a/source/packages/@aws-accelerator/config/lib/common-types/types.ts
+++ b/source/packages/@aws-accelerator/config/lib/common-types/types.ts
@@ -338,6 +338,7 @@ export const lifecycleRuleConfig = t.interface({
   noncurrentVersionExpiration: optional(t.number),
   noncurrentVersionTransitions: optional(t.array(transition)),
   transitions: optional(t.array(transition)),
+  prefix: optional(t.string),
 });
 
 export const resourcePolicyStatement = t.interface({
@@ -355,6 +356,7 @@ export class LifeCycleRule implements t.TypeOf<typeof lifecycleRuleConfig> {
   readonly noncurrentVersionExpiration: number = 366;
   readonly noncurrentVersionTransitions: Transition[] = [];
   readonly transitions: Transition[] = [];
+  readonly prefix: string = '';
 }
 
 export const shareTargets = t.interface({

--- a/source/packages/@aws-accelerator/constructs/lib/aws-s3/bucket.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-s3/bucket.ts
@@ -59,6 +59,7 @@ export interface S3LifeCycleRule {
   noncurrentVersionExpiration: number;
   transitions: Transition[];
   noncurrentVersionTransitions: Transition[];
+  prefix: string;
 }
 
 /**
@@ -349,19 +350,19 @@ export class Bucket extends Construct {
           };
           noncurrentVersionTransitions.push(noncurrentVersionTransitionsConfig);
         }
-
         this.lifecycleRules.push({
           abortIncompleteMultipartUploadAfter: cdk.Duration.days(
             lifecycleRuleConfig.abortIncompleteMultipartUploadAfter,
           ),
           enabled: lifecycleRuleConfig.enabled,
           expiration: cdk.Duration.days(lifecycleRuleConfig.expiration),
+          prefix: lifecycleRuleConfig.prefix,
           transitions,
           noncurrentVersionTransitions,
           noncurrentVersionExpiration: cdk.Duration.days(lifecycleRuleConfig.noncurrentVersionExpiration),
           expiredObjectDeleteMarker: lifecycleRuleConfig.expiredObjectDeleteMarker,
-          id: `LifecycleRule${this.props.s3BucketName}`,
-        });
+          id: `LifecycleRule${this.props.s3BucketName}${lifecycleRuleConfig.prefix}`,
+          });
       }
     } else {
       this.lifecycleRules.push({

--- a/source/packages/@aws-accelerator/constructs/lib/aws-s3/bucket.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-s3/bucket.ts
@@ -362,7 +362,7 @@ export class Bucket extends Construct {
           noncurrentVersionExpiration: cdk.Duration.days(lifecycleRuleConfig.noncurrentVersionExpiration),
           expiredObjectDeleteMarker: lifecycleRuleConfig.expiredObjectDeleteMarker,
           id: `LifecycleRule${this.props.s3BucketName}${lifecycleRuleConfig.prefix}`,
-          });
+        });
       }
     } else {
       this.lifecycleRules.push({

--- a/source/packages/@aws-accelerator/constructs/test/aws-s3/__snapshots__/bucket.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-s3/__snapshots__/bucket.test.ts.snap
@@ -802,6 +802,7 @@ exports[`Bucket Construct(Bucket):  Snapshot Test 1`] = `
                     {
                       "Ref": "AWS::Region",
                     },
+                    "object-prefix",
                   ],
                 ],
               },
@@ -814,6 +815,7 @@ exports[`Bucket Construct(Bucket):  Snapshot Test 1`] = `
                   "TransitionInDays": 365,
                 },
               ],
+              "Prefix": "object-prefix",
               "Status": "Enabled",
               "Transitions": [
                 {

--- a/source/packages/@aws-accelerator/constructs/test/aws-s3/bucket.test.ts
+++ b/source/packages/@aws-accelerator/constructs/test/aws-s3/bucket.test.ts
@@ -211,6 +211,7 @@ describe('Bucket', () => {
       s3LifeCycleRules: [
         {
           id: '1',
+          prefix: 'object-prefix',
           abortIncompleteMultipartUploadAfter: 1,
           enabled: true,
           expiration: 24,


### PR DESCRIPTION
In the case of the central logs bucket ([log-centralization-methods)](https://github.com/awslabs/landing-zone-accelerator-on-aws#log-centralization-methods), there are 16 different prefixes that logs are aggregated within the single bucket.

Without the ability to assign a prefix, each bucket only has the ability for a bucket wide S3 transition plan.

This allows logs from different sources to be transitioned at different periods.

- [x] Need some assistance with updating snapshots
- [ ] Need some assistance updating docs


Further move, `reports.costAndUsageReport.lifecycleRules` does not add a rule prefix in the central bucket (as one might expect):
~~~yaml
reports:
  costAndUsageReport:
    ...
    lifecycleRules:
      - enabled: true
        abortIncompleteMultipartUpload: 7
        expiration: 111
        noncurrentVersionExpiration: 111
~~~
![Screenshot 2023-07-26 at 2 17 29 pm](https://github.com/awslabs/landing-zone-accelerator-on-aws/assets/17537115/37965157-1c51-4167-b980-f0531f39867c)

