### PR TITLE
feat(validation): Cost and Reporting Additional Artifacts

### DIFF
--- a/source/packages/@aws-accelerator/config/validator/global-config-validator.ts
+++ b/source/packages/@aws-accelerator/config/validator/global-config-validator.ts
@@ -68,6 +68,10 @@ export class GlobalConfigValidator {
     this.validateLifecycleRuleExpirationForAccessLogBucket(values, errors);
     this.validateLifecycleRuleExpirationForReports(values, errors);
     //
+    // validate cost and reporting configuration
+    //
+    this.validateAdditionalArtifactsForCostAndReporting(values, errors);
+    //
     // validate cloudwatch logging
     //
     this.validateCloudWatch(values, configDir, ouIdNames, accountNames, errors);
@@ -210,6 +214,18 @@ export class GlobalConfigValidator {
       if (lifecycleRule.expiration && lifecycleRule.expiredObjectDeleteMarker) {
         errors.push('You may not configure expiredObjectDeleteMarker with expiration. Cost Reporting');
       }
+    }
+  }
+
+  /**
+   * Function to validate additional artifact config for Cost Reporting
+   * @param values
+   */
+
+  private validateAdditionalArtifactsForCostAndReporting(values: GlobalConfig, errors: string[]) {
+    if ((values.reports?.costAndUsageReport?.additionalArtifacts ?? []).length > 1) {
+      const enabledAdditionalArtifacts = values.reports?.costAndUsageReport?.additionalArtifacts;
+      errors.push(`You may not configure more than one "additionalArtifacts" in Cost Reporting: ${enabledAdditionalArtifacts}`)
     }
   }
 


### PR DESCRIPTION
*Description of changes:*

Currently [additionalArtifacts](https://awslabs.github.io/landing-zone-accelerator-on-aws/classes/_aws_accelerator_config.CostAndUsageReportConfig.html#additionalArtifacts) is defined a list... 
> A list of manifests that you want Amazon Web Services to create for this report.

Defined in `global-config.yaml` as:
~~~yaml
reports:
  costAndUsageReport:
...
    additionalArtifacts:
      - ATHENA
~~~

Specification as a list leans the user to believe multiple values can be supplied.

This is not supported:
<img width="856" alt="image" src="https://github.com/awslabs/landing-zone-accelerator-on-aws/assets/17537115/7810486d-9463-4a00-a622-6be3a1434a77">

![image](https://github.com/awslabs/landing-zone-accelerator-on-aws/assets/17537115/80adc23c-745a-4e52-9f2b-019321c84ada)


### Validation working with:
~~~yaml

reports:
  costAndUsageReport:
...
    # Lacking clean docs: https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/8c306e92e9c407973a65b75d7a5fa58cf3c6b81c/source/packages/@aws-accelerator/config/lib/global-config.ts#L115
    additionalArtifacts:
      - ATHENA
      - QUICKSIGHT
~~~
<img width="1011" alt="image" src="https://github.com/awslabs/landing-zone-accelerator-on-aws/assets/17537115/4aac17a5-c322-4b78-928c-3897f3524701">

