### PR TITLE
feat(SCP): update to restrict modification on guardDuty

### DIFF
--- a/reference/sample-configurations/aws-best-practices/service-control-policies/guardrails-2.json
+++ b/reference/sample-configurations/aws-best-practices/service-control-policies/guardrails-2.json
@@ -63,6 +63,7 @@
         "guardduty:DeleteDetector",
         "guardduty:DeleteMembers",
         "guardduty:UpdateDetector",
+        "guardduty:UpdatePublishingDestination",
         "guardduty:StopMonitoringMembers",
         "guardduty:Disassociate*",
         "securityhub:BatchDisableStandards",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Originally rather than disallowing an user to change the S3 destination, this was not blocked.
Now, when attempting to change the destination - SCP will enforce

