### PR TITLE
Added a CF parameter to the InstallerStack to be able to opt in or out of anonymized data collection

### DIFF
--- a/source/packages/@aws-accelerator/installer/lib/installer-stack.ts
+++ b/source/packages/@aws-accelerator/installer/lib/installer-stack.ts
@@ -127,6 +127,13 @@ export class InstallerStack extends cdk.Stack {
     maxLength: 15,
   });
 
+  private readonly sendAnonymousDataToAWS = new cdk.CfnParameter(this, 'sendAnonymousDataToAWS', {
+    type: 'String',
+    description: 'Whether to send anonymous data to AWS',
+    default: 'Yes',
+    allowedValues: ['Yes', 'No'],
+  });
+
   /**
    * Use existing configuration repository name flag
    * @private
@@ -441,6 +448,7 @@ export class InstallerStack extends cdk.Stack {
       repositoryOwner: this.repositoryOwner,
       repositoryBranchName: this.repositoryBranchName,
       repositoryName: this.repositoryName,
+      sendAnonymousDataToAWS: this.sendAnonymousDataToAWS,
     });
 
     // Create Accelerator Installer KMS Key

--- a/source/packages/@aws-accelerator/installer/lib/solutions-helper.ts
+++ b/source/packages/@aws-accelerator/installer/lib/solutions-helper.ts
@@ -23,21 +23,29 @@ export interface SolutionHelperProps {
   readonly repositoryOwner: cdk.CfnParameter;
   readonly repositoryBranchName: cdk.CfnParameter;
   readonly repositoryName: cdk.CfnParameter;
+  readonly sendAnonymousDataToAWS: cdk.CfnParameter;
 }
 
 export class SolutionHelper extends Construct {
   constructor(scope: Construct, id: string, props: SolutionHelperProps) {
     super(scope, id);
+    const sendAnonymousDataToAWS = new cdk.CfnParameter(this, 'SendAnonymousDataToAWS', {
+      type: 'String',
+      allowedValues: ['Yes', 'No'],
+      default: 'Yes',
+      description: 'Whether to send anonymous data to AWS',
+    });
+
     const metricsMapping = new cdk.CfnMapping(this, 'AnonymousData', {
       mapping: {
         SendAnonymizedData: {
-          Data: 'Yes',
+          Data: sendAnonymousDataToAWS.valueAsString,
         },
       },
     });
 
     const metricsCondition = new cdk.CfnCondition(this, 'AnonymousDataToAWS', {
-      expression: cdk.Fn.conditionEquals(metricsMapping.findInMap('SendAnonymizedData', 'Data'), 'Yes'),
+      expression: cdk.Fn.conditionEquals(metricsMapping.findInMap('SendAnonymizedData', 'Data'), sendAnonymousDataToAWS.valueAsString),
     });
 
     const helperFunction = new lambda.Function(this, 'SolutionHelper', {

--- a/source/packages/@aws-accelerator/installer/lib/solutions-helper.ts
+++ b/source/packages/@aws-accelerator/installer/lib/solutions-helper.ts
@@ -29,23 +29,16 @@ export interface SolutionHelperProps {
 export class SolutionHelper extends Construct {
   constructor(scope: Construct, id: string, props: SolutionHelperProps) {
     super(scope, id);
-    const sendAnonymousDataToAWS = new cdk.CfnParameter(this, 'SendAnonymousDataToAWS', {
-      type: 'String',
-      allowedValues: ['Yes', 'No'],
-      default: 'Yes',
-      description: 'Whether to send anonymous data to AWS',
-    });
-
     const metricsMapping = new cdk.CfnMapping(this, 'AnonymousData', {
       mapping: {
         SendAnonymizedData: {
-          Data: sendAnonymousDataToAWS.valueAsString,
+          Data: props.sendAnonymousDataToAWS.valueAsString,
         },
       },
     });
 
     const metricsCondition = new cdk.CfnCondition(this, 'AnonymousDataToAWS', {
-      expression: cdk.Fn.conditionEquals(metricsMapping.findInMap('SendAnonymizedData', 'Data'), sendAnonymousDataToAWS.valueAsString),
+      expression: cdk.Fn.conditionEquals(metricsMapping.findInMap('SendAnonymizedData', 'Data'), 'Yes'),
     });
 
     const helperFunction = new lambda.Function(this, 'SolutionHelper', {


### PR DESCRIPTION
*Issue # https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/275

*Description of changes:*
Updated the AWSAccelerator-InstallerStack with a new parameter to be able to opt in (Yes) or out (No) of anonymized data collection. 
Default set to Yes (Opt-In).

This is a quality of life update where editing the CloudFormation template code is required every time the installer stack template is updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
