### PR TITLE
Add description property to Permission Sets

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -967,6 +967,7 @@ export class OperationsStack extends AcceleratorStack {
         customerManagedPolicyReferencesList.length > 0 ? customerManagedPolicyReferencesList : undefined,
       sessionDuration: convertedSessionDuration,
       permissionsBoundary: permissionsBoundary,
+      description: identityCenterPermissionSet.description,
     };
 
     if (identityCenterPermissionSet.policies?.inlinePolicy) {
@@ -987,6 +988,7 @@ export class OperationsStack extends AcceleratorStack {
         sessionDuration: convertedSessionDuration ?? undefined,
         inlinePolicy: inlinePolicyDocument,
         permissionsBoundary: permissionsBoundary,
+        description: identityCenterPermissionSet.description,
       };
     }
 

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
@@ -6202,6 +6202,30 @@ exports[`OrganizationsStack Construct(OrganizationsStack):  Snapshot Test 1`] = 
             },
             "sessionDuration": 60,
           },
+          {
+            "description": "This is a useful permission set description.",
+            "name": "PermissionSet3",
+            "policies": {
+              "acceleratorManaged": [
+                "lzaManagedPolicy01",
+              ],
+              "awsManaged": [
+                "PowerUserAccess",
+                "ReadOnlyAccess",
+              ],
+              "customerManaged": [
+                "ResourceConfigurationCollectorPolicy",
+              ],
+              "inlinePolicy": "REPLACED-JSON-PATH.json",
+              "permissionsBoundary": {
+                "customerManagedPolicy": {
+                  "name": "lzaManagedPolicy01",
+                  "path": "/",
+                },
+              },
+            },
+            "sessionDuration": 60,
+          },
         ],
         "partition": {
           "Ref": "AWS::Partition",

--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/iam-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/iam-config.yaml
@@ -92,6 +92,24 @@ identityCenter:
             path: /
           # awsManagedPolicyName: PowerUserAccess
       sessionDuration: 60
+    - name: PermissionSet3
+      policies:
+        awsManaged:
+          - PowerUserAccess
+          - ReadOnlyAccess
+        customerManaged:
+          - ResourceConfigurationCollectorPolicy
+        acceleratorManaged:
+          - lzaManagedPolicy01
+          # - lzaManagedPolicy02
+        inlinePolicy: iam-policies/sso-permissionSet1-inline-policy.json
+        permissionsBoundary: 
+          customerManagedPolicy:
+            name: lzaManagedPolicy01
+            path: /
+          # awsManagedPolicyName: PowerUserAccess
+      sessionDuration: 60
+      description: "This is a useful permission set description."
   identityCenterAssignments:
     - name: Assignment1
       permissionSetName: PermissionSet1

--- a/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/iam-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/iam-config.yaml
@@ -89,6 +89,24 @@ identityCenter:
             path: /
           # awsManagedPolicyName: PowerUserAccess
       sessionDuration: 60
+    - name: PermissionSet3
+      policies:
+        awsManaged:
+          - PowerUserAccess
+          - ReadOnlyAccess
+        customerManaged:
+          - ResourceConfigurationCollectorPolicy
+        acceleratorManaged:
+          - lzaManagedPolicy01
+          # - lzaManagedPolicy02
+        inlinePolicy: iam-policies/sso-permissionSet1-inline-policy.json
+        permissionsBoundary: 
+          customerManagedPolicy:
+            name: lzaManagedPolicy01
+            path: /
+          # awsManagedPolicyName: PowerUserAccess
+      sessionDuration: 60
+      description: "This is a useful permission set description."
   identityCenterAssignments:
     - name: Assignment1
       permissionSetName: PermissionSet1

--- a/source/packages/@aws-accelerator/config/lib/iam-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/iam-config.ts
@@ -94,6 +94,7 @@ export class IamConfigTypes {
     name: t.nonEmptyString,
     policies: t.optional(this.identityCenterPoliciesConfig),
     sessionDuration: t.optional(t.number),
+    description: t.optional(t.string),
   });
 
   /**
@@ -1111,6 +1112,7 @@ export class RoleConfig implements t.TypeOf<typeof IamConfigTypes.roleConfig> {
  *           path: /
  *         awsManagedPolicyName: PowerUserAccess
  *     sessionDuration: 60
+ *     description: A permission set to...
  *  identityCenterAssignments:
  *   - name: Assignment1
  *     permissionSetName: PermissionSet1
@@ -1336,6 +1338,7 @@ export class IdentityCenterPoliciesConfig implements t.TypeOf<typeof IamConfigTy
  *           path: /
  *         awsManagedPolicyName: PowerUserAccess
  *     sessionDuration: 60
+ *     description: A permission set to...
  * ```
  */
 export class IdentityCenterPermissionSetConfig
@@ -1358,6 +1361,12 @@ export class IdentityCenterPermissionSetConfig
    * @default undefined
    */
   readonly sessionDuration: number | undefined = undefined;
+
+  /**
+   * A description string for the Permission Set
+   * @default undefined
+   */
+  readonly description: string | undefined = undefined;
 }
 
 /**
@@ -1714,6 +1723,7 @@ export class IamConfig implements t.TypeOf<typeof IamConfigTypes.iamConfig> {
    *            path: /
    *          awsManagedPolicyName: PowerUserAccess
    *      sessionDuration: 60
+   *      description: A permission set to...
    *   identityCenterAssignments:
    *     - name: Assignment1
    *       permissionSetName: PermissionSet1

--- a/source/packages/@aws-accelerator/config/validator/iam-config-validator.ts
+++ b/source/packages/@aws-accelerator/config/validator/iam-config-validator.ts
@@ -479,6 +479,11 @@ export class IamConfigValidator {
     // Validate PermissionSet permissions boundary
     //
     this.validateIdentityCenterPermissionSetPermissionsBoundary(iamConfig, errors);
+
+    //
+    // Validate PermissionSet descriptions
+    //
+    this.validateIdentityCenterPermissionSetPermissionsDescriptions(iamConfig, errors);
   }
 
   /**
@@ -611,6 +616,40 @@ export class IamConfigValidator {
           ) {
             errors.push(
               `Identity center ${iamConfig.identityCenter.name} permission set ${identityCenterPermissionSet.name} permissions boundary can either have customerManagedPolicy or managedPolicy, both the properties can't be defined.`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Function to validate Identity Center Permission set permissionsBoundary
+   * @param iamConfig
+   * @param errors
+   */
+  private validateIdentityCenterPermissionSetPermissionsDescriptions(
+    iamConfig: t.TypeOf<typeof IamConfigTypes.iamConfig>,
+    errors: string[],
+  ) {
+    if (iamConfig.identityCenter) {
+      const identityCenter = iamConfig.identityCenter;
+      for (const identityCenterPermissionSet of identityCenter.identityCenterPermissionSets ?? []) {
+        if (identityCenterPermissionSet.description) {
+          if (identityCenterPermissionSet.description.length > 700) {
+            errors.push(
+              `Identity center ${iamConfig.identityCenter.name} permission set ${identityCenterPermissionSet.name} description is too long.`,
+            );
+          }
+          /* eslint-disable no-control-regex */
+          /* Disabling no-control-regex because this is how it's defined at
+             https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-permissionset.html#cfn-sso-permissionset-description
+          */
+          const descriptionRegex = /^[\u0009\u000A\u000D\u0020-\u007E\u00A1-\u00FF]*$/;
+          /* eslint-enable no-control-regex */
+          if (!descriptionRegex.test(identityCenterPermissionSet.description)) {
+            errors.push(
+              `Identity center ${iamConfig.identityCenter.name} permission set ${identityCenterPermissionSet.name} description has invalid characters.`,
             );
           }
         }


### PR DESCRIPTION
*Issue #307 , if available:*

*Description of changes:*
Adds the ability to set descriptions on Permission Sets. Updates tests and validation to handle this as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
