### PR TITLE
Support multiple sets of shared VPC interface endpoints

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-stack.ts
@@ -480,7 +480,9 @@ export abstract class NetworkStack extends AcceleratorStack {
     const zoneMap = new Map<string, string>();
 
     for (const vpcItem of vpcResources) {
-      if (vpcItem.interfaceEndpoints?.central) {
+      const hasSharedEndpointsId = !(vpcItem.interfaceEndpoints?.sharedEndpointsId === undefined);
+      const hasCentralEndpointsFlag = vpcItem.interfaceEndpoints?.central ?? false;
+      if (hasSharedEndpointsId || hasCentralEndpointsFlag) {
         // Set interface endpoint DNS names
         for (const endpointItem of vpcItem.interfaceEndpoints?.endpoints ?? []) {
           const endpointDns = cdk.aws_ssm.StringParameter.valueForStringParameter(

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-vpc-dns-stack/network-vpc-dns-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-vpc-dns-stack/network-vpc-dns-stack.ts
@@ -102,8 +102,11 @@ export class NetworkVpcDnsStack extends NetworkStack {
         this.logger.error(`Unable to locate VPC ${vpcItem.name}`);
         throw new Error(`Configuration validation failed at runtime.`);
       }
+
+      const hasSharedEndpointsId = !(vpcItem.interfaceEndpoints?.sharedEndpointsId === undefined);
+      const hasCentralEndpointsFlag = vpcItem.interfaceEndpoints?.central ?? false;
       // Create private hosted zones
-      if (vpcItem.interfaceEndpoints?.central) {
+      if (hasSharedEndpointsId || hasCentralEndpointsFlag) {
         this.createHostedZones(vpcItem, vpcId, maps.endpoint, maps.zone);
       }
 

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-vpc-endpoints-stack/network-vpc-endpoints-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/network-stacks/network-vpc-endpoints-stack/network-vpc-endpoints-stack.ts
@@ -681,7 +681,10 @@ export class NetworkVpcEndpointsStack extends NetworkStack {
 
     // Create the interface endpoint
     const securityGroupMap = new Map<string, SecurityGroup>();
-    const privateDnsValue = !vpcItem.interfaceEndpoints?.central ?? true;
+
+    const hasSharedEndpointsId = !(vpcItem.interfaceEndpoints?.sharedEndpointsId === undefined);
+    const hasCentralEndpointsFlag = vpcItem.interfaceEndpoints?.central ?? false;
+    const privateDnsValue = !(hasCentralEndpointsFlag || hasSharedEndpointsId);
 
     for (const endpointItem of vpcItem.interfaceEndpoints?.endpoints ?? []) {
       if (this.isManagedByAsea(AseaResourceType.VPC_ENDPOINT, `${vpcItem.name}/${endpointItem.service}`)) {

--- a/source/packages/@aws-accelerator/config/lib/network-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/network-config.ts
@@ -318,6 +318,7 @@ export class NetworkConfigTypes {
     endpoints: t.array(this.interfaceEndpointServiceConfig),
     subnets: t.array(t.nonEmptyString),
     central: t.optional(t.boolean),
+    sharedEndpointsId: t.optional(t.string),
     allowedCidrs: t.optional(t.array(t.nonEmptyString)),
   });
 
@@ -574,6 +575,7 @@ export class NetworkConfigTypes {
     ipamAllocations: t.optional(t.array(this.ipamAllocationConfig)),
     natGateways: t.optional(t.array(this.natGatewayConfig)),
     useCentralEndpoints: t.optional(t.boolean),
+    sharedEndpointsId: t.optional(t.string),
     securityGroups: t.optional(t.array(this.securityGroupConfig)),
     networkAcls: t.optional(t.array(this.networkAclConfig)),
     queryLogs: t.optional(t.array(t.nonEmptyString)),
@@ -606,6 +608,7 @@ export class NetworkConfigTypes {
     ipamAllocations: t.optional(t.array(this.ipamAllocationConfig)),
     natGateways: t.optional(t.array(this.natGatewayConfig)),
     useCentralEndpoints: t.optional(t.boolean),
+    sharedEndpointsId: t.optional(t.string),
     securityGroups: t.optional(t.array(this.securityGroupConfig)),
     networkAcls: t.optional(t.array(this.networkAclConfig)),
     queryLogs: t.optional(t.array(t.nonEmptyString)),
@@ -2968,12 +2971,28 @@ export class InterfaceEndpointConfig implements t.TypeOf<typeof NetworkConfigTyp
    * created for each of them. These hosted zones are associated with any VPCs configured
    * with the `useCentralEndpoints` property enabled.
    *
-   * **NOTE**: You may only define one centralized endpoint VPC per region.
+   * **NOTE**: You may only define one centralized endpoint VPC per region and this may not be used
+   * in conjunction with {@link sharedEndpointsId}
    *
    * For additional information on this pattern, please refer to
    * {@link https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/main/FAQ.md#how-do-i-define-a-centralized-interface-endpoint-vpc | our FAQ}.
    */
   readonly central: boolean | undefined = undefined;
+  /**
+   * (OPTIONAL) Set to define interface endpoints as centralized endpoints with the given identifier.
+   *
+   * @remarks
+   * Endpoints defined as centralized endpoints will have Route 53 private hosted zones
+   * created for each of them. These hosted zones are associated with any VPCs configured
+   * with the `sharedEndpointsId` property which matches.
+   *
+   * **NOTE**: You may only define one centralized endpoint VPC per region and this may not be used
+   * in conjunction with {@link central}
+   *
+   * For additional information on this pattern, please refer to
+   * {@link https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/main/FAQ.md#how-do-i-define-a-centralized-interface-endpoint-vpc | our FAQ}.
+   */
+  readonly sharedEndpointsId: string | undefined = undefined;
   /**
    * (OPTIONAL) An array of source CIDRs allowed to communicate with the endpoints.
    *
@@ -4861,6 +4880,21 @@ export class VpcConfig implements t.TypeOf<typeof NetworkConfigTypes.vpcConfig> 
   readonly useCentralEndpoints: boolean | undefined = false;
 
   /**
+   * (OPTIONAL) When set, this VPC will be configured to utilize centralized
+   * endpoints with the given identfier. This includes having the Route 53 Private
+   * Hosted Zone associated with this VPC. Centralized endpoints are configured per
+   * region, and can span to spoke accounts
+   *
+   * @remarks
+   * A VPC deployed in the same region as this VPC in network-config.yaml must be configured with {@link InterfaceEndpointConfig}
+   * `sharedEndpointsId` property matching the id set here to utilize centralized endpoints.
+   *
+   * For additional information on this pattern, please refer to
+   * {@link https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/main/FAQ.md#how-do-i-define-a-centralized-interface-endpoint-vpc | our FAQ}.
+   */
+  readonly sharedEndpointsId: string | undefined = undefined;
+
+  /**
    * (OPTIONAL) A list of Security Groups to deploy for this VPC
    *
    * @default undefined
@@ -5191,6 +5225,21 @@ export class VpcTemplatesConfig implements t.TypeOf<typeof NetworkConfigTypes.vp
    * `central` property set to `true` to utilize centralized endpoints.
    */
   readonly useCentralEndpoints: boolean | undefined = false;
+
+  /**
+   * (OPTIONAL) When set, this VPC will be configured to utilize centralized
+   * endpoints with the given identfier. This includes having the Route 53 Private
+   * Hosted Zone associated with this VPC. Centralized endpoints are configured per
+   * region, and can span to spoke accounts
+   *
+   * @remarks
+   * A VPC deployed in the same region as this VPC in network-config.yaml must be configured with {@link InterfaceEndpointConfig}
+   * `sharedEndpointsId` property matching the id set here to utilize centralized endpoints.
+   *
+   * For additional information on this pattern, please refer to
+   * {@link https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/main/FAQ.md#how-do-i-define-a-centralized-interface-endpoint-vpc | our FAQ}.
+   */
+  readonly sharedEndpointsId: string | undefined = undefined;
 
   /**
    * (OPTIONAL) A list of Security Groups to deploy for this VPC

--- a/source/packages/@aws-accelerator/config/validator/network-config-validator/vpc-validator.ts
+++ b/source/packages/@aws-accelerator/config/validator/network-config-validator/vpc-validator.ts
@@ -98,6 +98,15 @@ export class VpcValidator {
         );
       }
 
+      if (
+        vpc.interfaceEndpoints?.sharedEndpointsId !== undefined &&
+        !helpers.matchesRegex(vpc.interfaceEndpoints.sharedEndpointsId, '^[a-z]{1,8}$')
+      ) {
+        errors.push(
+          `[VPC ${vpc.name}]: sharedEndpointId must be between 1-8 characters containing only lowercase letters`,
+        );
+      }
+
       if (vpc.interfaceEndpoints?.sharedEndpointsId !== undefined && NetworkConfigTypes.vpcConfig.is(vpc)) {
         let vpcconfigs = sharedEndpointsVpcs.get(vpc.interfaceEndpoints?.sharedEndpointsId);
         if (vpcconfigs === undefined) {


### PR DESCRIPTION
*Issue #313:*

*Description of changes:*

Update to support providing multiple sets of VPC Interface endpoints based on an unique identifier, rather than the central boolean flag.

- Added new _sharedEndpointsId_ parameter to the object model (alongside central and _useCentralEndpoint_ boolean flag)
- Updated validator to ensure _sharedEndpointsId_ cannot be used on the same VPC as the _central_ flag
- Updated validator to ensure that _sharedEndpointsId_ cannot be referenced on a VPC unless it's used to share endpoints
- Setup PHZ's for VPC's that are using _sharedEndpointsId_
- Add additional role per set of shared endpoints for creating the associations. This is unique based on the _sharedEndpointsId_ value set (and the validator ensures that the value is suitable for including in the role name)
- Additional utility functions on the accelerator-stack.ts to support looking up a VPC configuration based on _sharedEndpointId_, and to get all available sharedEndpointIds.

Usage:
In the config for the VPC sharing the endpoints:

```
- name: Dev-Network-Boundary
  account: Dev-Network
  ...
  interfaceEndpoints:
      sharedEndpointsId: dev
      subnets:
        - Dev-Network-Endpoints-A
        - Dev-Network-Endpoints-B
        - Dev-Network-Endpoints-C
      endpoints:
        - service: ec2
        - service: sts
        - 
```

In the config for the VPC using the endpoints
```
- name: Dev-Workload
  account: Dev-Workload
  ...
  sharedEndpointsId: dev
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
