### PR TITLE
Removing retired Security Hub controls tse cccs

### DIFF
--- a/reference/sample-configurations/lza-sample-config-cccs-medium/config/security-config.yaml
+++ b/reference/sample-configurations/lza-sample-config-cccs-medium/config/security-config.yaml
@@ -47,13 +47,11 @@ centralSecurityServices:
         controlsToDisable:
           - IAM.1
           - EC2.10
-          - Lambda.4
       - name: PCI DSS v3.2.1
         enable: true
         controlsToDisable:
           - PCI.IAM.3
           - PCI.S3.3
-          - PCI.EC2.3
           - PCI.Lambda.2
       - name: CIS AWS Foundations Benchmark v1.2.0
         enable: true

--- a/reference/sample-configurations/lza-sample-config-tse-se/config/security-config.yaml
+++ b/reference/sample-configurations/lza-sample-config-tse-se/config/security-config.yaml
@@ -47,13 +47,11 @@ centralSecurityServices:
         controlsToDisable:
           - IAM.1
           - EC2.10
-          - Lambda.4
       - name: PCI DSS v3.2.1
         enable: true
         controlsToDisable:
           - PCI.IAM.3
           - PCI.S3.3
-          - PCI.EC2.3
           - PCI.Lambda.2
       - name: CIS AWS Foundations Benchmark v1.2.0
         enable: true


### PR DESCRIPTION
*Issue #317 *

*Description of changes:*
AWS Security Hub retired controls Lambda.4 and PCI.EC2.3. Removing them from the CCCS and TSE sample configs. See https://docs.aws.amazon.com/securityhub/latest/userguide/doc-history.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
