### PR TITLE
Update ssmmessage for scp-hlc-hipaa-service.json

### DIFF
--- a/reference/sample-configurations/lza-sample-config-healthcare/service-control-policies/scp-hlc-hipaa-service.json
+++ b/reference/sample-configurations/lza-sample-config-healthcare/service-control-policies/scp-hlc-hipaa-service.json
@@ -142,6 +142,7 @@
                 "sns:*",
                 "sqs:*",
                 "ssm:*",
+                "ssmmessages:*"
                 "sso:*",
                 "sso-directory:*",
                 "states:*",


### PR DESCRIPTION
Fixing "is not authorized to perform: ssmmessages:CreateDataChannel on resource: arn:aws:ssmmessages:us-east-1:<AcctiD>:* with an explicit deny in a service control policy</Message> </AccessDeniedException>

*Issue #, if available:*
N/A
*Description of changes:*
This SCP `scp-hlc-hipaa-service.json` enables only HIPAA eligible services once applied. But it was missing ssmmessages and due to that Session Manager System Manager functionalities were impacted. Please see below error message. 
```
failed: failed to create websocket for datachannel with error: CreateDataChannel failed with no output or error: createDataChannel request failed: unexpected response from the service <AccessDeniedException> <Message>User: arn:aws:sts::<AcctId>:assumed-role/EC2-Default-SSM-AD-Role/i-xxxxx is not authorized to perform: ssmmessages:CreateDataChannel on resource: arn:aws:ssmmessages:us-east-1:<AcctId>:* with an explicit deny in a service control policy</Message> </AccessDeniedException>
```
Adding `ssmmessages:*` in this SCP and then above issue remediated. 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
