### PR TITLE
chore(config): Add KMS key guardrail to sample SCP

### DIFF
--- a/reference/sample-configurations/lza-sample-config/README.md
+++ b/reference/sample-configurations/lza-sample-config/README.md
@@ -209,6 +209,7 @@ These guardrails apply across the organization and protect the resources deploye
 | SnsStatement                           | Prevents creation, deletion and modification of a protected SNS topics                                      |
 | EbsEncryptionStatement                 | Prevents disabling of EBS Encryption                                                                        |
 | MacieServiceStatement                  | Prevents the deletion and modification to AWS security services Macie                                       |
+| PreventKMSKeyModification              | Prevents the deletion and modification of protected KMS keys                                                |
 
 ### 4.8.2 Quarantine
 

--- a/reference/sample-configurations/lza-sample-config/service-control-policies/guardrails-1.json
+++ b/reference/sample-configurations/lza-sample-config/service-control-policies/guardrails-1.json
@@ -129,6 +129,34 @@
           ]
         }
       }
+    },
+    {
+      "Sid": "PreventKMSKeyModification",
+      "Effect": "Deny",
+      "Action": [
+        "kms:DeleteAlias",
+        "kms:DisableKey",
+        "kms:DisableKeyRotation",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion",
+        "kms:UpdateAlias",
+        "kms:UpdateKeyDescription"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "ArnNotLike": {
+          "aws:PrincipalARN": [
+            "arn:${PARTITION}:iam::*:role/${ACCELERATOR_PREFIX}-*",
+            "arn:${PARTITION}:iam::*:role/${MANAGEMENT_ACCOUNT_ACCESS_ROLE}",
+            "arn:${PARTITION}:iam::*:role/cdk-accel-*"
+          ]
+        },
+        "ForAnyValue:StringLike": {
+          "kms:ResourceAliases": [
+            "alias/accelerator/*"
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is adding a statement to the guardrail SCP to prevent the deletion and modification of LZA KMS keys

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
