### PR TITLE
Fix hosted zone DNS for Sagemaker VPC Endpoints

### DIFF
--- a/source/packages/@aws-accelerator/constructs/lib/aws-route-53/hosted-zone.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-route-53/hosted-zone.ts
@@ -90,6 +90,12 @@ export class HostedZone extends cdk.Resource implements IHostedZone {
       case 'studio':
         hostedZoneName = `${service}.${region}.sagemaker.aws`;
         break;
+      case 'sagemaker.api':
+        hostedZoneName = `api.sagemaker.${region}.sagemaker.aws`;
+        break;
+      case 'sagemaker.runtime':
+        hostedZoneName = `runtime.sagemaker.${region}.sagemaker.aws`;
+        break;
     }
     return hostedZoneName;
   }
@@ -107,6 +113,8 @@ export class HostedZone extends cdk.Resource implements IHostedZone {
       'studio',
       'codeartifact.api',
       'codeartifact.repositories',
+      'sagemaker.api',
+      'sagemaker.runtime',
     ];
     return ignoreServicesArray.includes(service);
   }


### PR DESCRIPTION
Currently the default DNS naming convention for Route 53 hosted zones of VPC endpoints is using sagemaker.api.{region}.amazonaws.com which is not the correct DNS for it as can be found in Endpoints & Quotas page https://docs.aws.amazon.com/general/latest/gr/sagemaker.html

This is also the case for sagemaker runtime as well.

*Issue #, if available:* 348

*Description of changes:*. See above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
