### PR TITLE
Resolve SSM Automation Documents Reference Error

### DIFF
--- a/source/packages/@aws-accelerator/config/lib/security-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/security-config.ts
@@ -2868,7 +2868,7 @@ export function IsPublicSsmDoc(documentName: string) {
   // - aws
   // - amazon
   // - amzn
-  const reservedPrefix = [/^AWSConfigRemediation-/, /^AWS-/i, /^AMZN-/i, /^AMAZON-/i];
+  const reservedPrefix = [/^AWS/i, /^AMZN-/i, /^AMAZON-/i];
   if (reservedPrefix.some(obj => obj.test(documentName))) {
     return true;
   }

--- a/source/packages/@aws-accelerator/config/lib/security-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/security-config.ts
@@ -2868,7 +2868,7 @@ export function IsPublicSsmDoc(documentName: string) {
   // - aws
   // - amazon
   // - amzn
-  const reservedPrefix = [/^AWS-/i, /^AMZN-/i, /^AMAZON-/i];
+  const reservedPrefix = [/^AWSConfigRemediation-/, /^AWS-/i, /^AMZN-/i, /^AMAZON-/i];
   if (reservedPrefix.some(obj => obj.test(documentName))) {
     return true;
   }

--- a/source/packages/@aws-accelerator/config/lib/security-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/security-config.ts
@@ -2868,7 +2868,7 @@ export function IsPublicSsmDoc(documentName: string) {
   // - aws
   // - amazon
   // - amzn
-  const reservedPrefix = [/^AWS/i, /^AMZN-/i, /^AMAZON-/i];
+  const reservedPrefix = [/^AWS-/i, /^AMZN-/i, /^AMAZON-/i, /^AWSEC2-/i, /^AWSConfigRemediation-/i, /^AWSSupport-/i];
   if (reservedPrefix.some(obj => obj.test(documentName))) {
     return true;
   }

--- a/source/packages/@aws-accelerator/config/test/security-config.test.ts
+++ b/source/packages/@aws-accelerator/config/test/security-config.test.ts
@@ -107,7 +107,7 @@ describe('should return right values for correct config', () => {
 });
 
 describe('isPublicSsmDoc', () => {
-  expect(IsPublicSsmDoc('AWSDoc')).toBe(true); // when using AWS docs expect to be public
+  expect(IsPublicSsmDoc('AWSDoc')).toBeFalsy(); // not public doc
   expect(IsPublicSsmDoc('Doc')).toBeFalsy(); // not public doc
   expect(IsPublicSsmDoc('AWSAccelerator-Attach-IAM-Instance-Profile')).toBeFalsy(); // not public doc
   expect(IsPublicSsmDoc('AWS-AWSAccelerator-Attach-IAM-Instance-Profile')).toBeTruthy(); //public doc

--- a/source/packages/@aws-accelerator/config/test/security-config.test.ts
+++ b/source/packages/@aws-accelerator/config/test/security-config.test.ts
@@ -107,7 +107,7 @@ describe('should return right values for correct config', () => {
 });
 
 describe('isPublicSsmDoc', () => {
-  expect(IsPublicSsmDoc('AWSDoc')).toBeFalsy(); // not public doc
+  expect(IsPublicSsmDoc('AWSDoc')).toBe(true); // when using AWS docs expect to be public
   expect(IsPublicSsmDoc('Doc')).toBeFalsy(); // not public doc
   expect(IsPublicSsmDoc('AWSAccelerator-Attach-IAM-Instance-Profile')).toBeFalsy(); // not public doc
   expect(IsPublicSsmDoc('AWS-AWSAccelerator-Attach-IAM-Instance-Profile')).toBeTruthy(); //public doc


### PR DESCRIPTION
The names of SSM Automation Documents start with "AWSConfigRemediation-" - the security-config.ts file only looks for documents starting with "AWS-", "AMZN-" and "AMAZON-" - which prevents the use of AWS Config automation documents. This PR fixes this and has been tested:

```
  │  ~/Doc/D/Training/landing-zone-accelerator-on-aws/source │   main !3  yarn validate-config ~/Documents/Documents\ -\ Gregory’s\ MacBook\ Air/Customers/xxxxx/aws-accelerator-config                                                                                                          ✔ │ 1m 45s  │ 16:25:10  
yarn run v1.22.21
$ ts-node ./packages/@aws-accelerator/accelerator/lib/config-validator.ts '/Users/greg/Documents/Documents - Gregory’s MacBook Air/Customers/xxxxx/aws-accelerator-config'
2024-04-03 16:26:33.096 | info | replacements-config | Loading replacements config substitution values
2024-04-03 16:26:33.110 | info | config-validator | Config source directory -  /Users/greg/Documents/Documents - Gregory’s MacBook Air/Customers/xxxxx/aws-accelerator-config
2024-04-03 16:26:33.111 | info | replacements-config | Loading replacements config substitution values
2024-04-03 16:26:33.114 | info | replacements-config | Loading replacements config substitution values
2024-04-03 16:26:33.115 | info | replacements-config | Loading replacements config substitution values
2024-04-03 16:26:33.131 | info | accounts-config-validator | accounts-config.yaml file validation started
2024-04-03 16:26:33.132 | info | customizations-config-validator | customizations-config.yaml file validation started
2024-04-03 16:26:33.132 | info | global-config-validator | global-config.yaml file validation started
2024-04-03 16:26:33.134 | info | global-config-validator | email count: 2
2024-04-03 16:26:33.135 | info | iam-config-validator | iam-config.yaml file validation started
2024-04-03 16:26:33.137 | info | network-config-validator | network-config.yaml file validation started
2024-04-03 16:26:33.160 | info | organization-config-validator | organization-config.yaml file validation started
2024-04-03 16:26:33.162 | info | security-config-validator | security-config.yaml file validation started
2024-04-03 16:26:33.163 | info | config-validator | Config file validation successful.
✨  Done in 8.13s.
```

security-config.yaml in config directory:
```
awsConfig:
  enableConfigurationRecorder: true
  enableDeliveryChannel: true
  ruleSets:
    - deploymentTargets:
        organizationalUnits:
          - Root
      rules:
        - name: accelerator-elb-logging-enabled
          identifier: ELB_LOGGING_ENABLED
          complianceResourceTypes:
            - AWS::ElasticLoadBalancing::LoadBalancer
            - AWS::ElasticLoadBalancingV2::LoadBalancer
          inputParameters:
            s3BucketNames: ${ACCEL_LOOKUP::Bucket:elbLogs}
          remediation:
            rolePolicyFile: custom-config-rules/elb-logging-enabled-remediation-role.json
            automatic: true
            targetId: AWSConfigRemediation-EnableLoggingForALBAndCLB
            retryAttemptSeconds: 60
            maximumAutomaticAttempts: 5
            parameters:
              - name: LoadBalancerArn
                value: RESOURCE_ID
                type: String
              - name: LogDestination
                value: ${ACCEL_LOOKUP::Bucket:elbLogs}
                type: StringList
```
![AWS SSM Managed Config Rule Document](https://github.com/awslabs/landing-zone-accelerator-on-aws/assets/118703312/f19bbcf2-1525-476a-a57a-5fbd44bee0cf)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
