### PR TITLE
fix: Disable duplicate management events for Lambda & S3 Cloudtrail event selectors

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
@@ -802,15 +802,23 @@ export class OrganizationsStack extends AcceleratorStack {
     });
 
     if (this.stackProperties.globalConfig.logging.cloudtrail.organizationTrailSettings?.s3DataEvents ?? true) {
-      organizationsTrail.addEventSelector(cdk.aws_cloudtrail.DataResourceType.S3_OBJECT, [
-        `arn:${cdk.Stack.of(this).partition}:s3:::`,
-      ]);
+      organizationsTrail.addEventSelector(
+        cdk.aws_cloudtrail.DataResourceType.S3_OBJECT,
+        [`arn:${cdk.Stack.of(this).partition}:s3:::`],
+        {
+          includeManagementEvents: false,
+        },
+      );
     }
 
     if (this.stackProperties.globalConfig.logging.cloudtrail.organizationTrailSettings?.lambdaDataEvents ?? true) {
-      organizationsTrail.addEventSelector(cdk.aws_cloudtrail.DataResourceType.LAMBDA_FUNCTION, [
-        `arn:${cdk.Stack.of(this).partition}:lambda`,
-      ]);
+      organizationsTrail.addEventSelector(
+        cdk.aws_cloudtrail.DataResourceType.LAMBDA_FUNCTION,
+        [`arn:${cdk.Stack.of(this).partition}:lambda`],
+        {
+          includeManagementEvents: false,
+        },
+      );
     }
 
     organizationsTrail.node.addDependency(enableCloudtrailServiceAccess);


### PR DESCRIPTION
*Issue #, if available:* #449

*Description of changes:*

Prevents duplicate management event selectors being created in the organisation Cloud Trail when Lambda & S3 event selectors are enabled via the global logging config.

Resulting CloudTrail event selector configuration:

```json
aws cloudtrail get-event-selectors --trail-name AWSAccelerator-Organizations-CloudTrail
{
    "TrailARN": "arn:aws:cloudtrail:eu-west-2:account-id:trail/AWSAccelerator-Organizations-CloudTrail",
    "EventSelectors": [
        {
            "ReadWriteType": "All",
            "IncludeManagementEvents": false,
            "DataResources": [
                {
                    "Type": "AWS::Lambda::Function",
                    "Values": [
                        "arn:aws:lambda"
                    ]
                }
            ],
            "ExcludeManagementEventSources": []
        },
        {
            "ReadWriteType": "All",
            "IncludeManagementEvents": false,
            "DataResources": [
                {
                    "Type": "AWS::S3::Object",
                    "Values": [
                        "arn:aws:s3:::"
                    ]
                }
            ],
            "ExcludeManagementEventSources": []
        },
        {
            "ReadWriteType": "All",
            "IncludeManagementEvents": true,
            "DataResources": [],
            "ExcludeManagementEventSources": []
        }
    ]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
