### PR TITLE
chore(cdk-plugin-assume-role): migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/source/packages/@aws-cdk-extensions/cdk-plugin-assume-role/lib/assume-role-plugin.ts
+++ b/source/packages/@aws-cdk-extensions/cdk-plugin-assume-role/lib/assume-role-plugin.ts
@@ -12,7 +12,7 @@
  */
 
 import { Plugin, PluginHost } from 'aws-cdk/lib/api/plugin';
-import * as AWS from 'aws-sdk';
+import { Credentials } from '@aws-sdk/client-sts';
 
 import { AssumeRoleProviderSource } from './assume-role-provider-source';
 
@@ -24,7 +24,7 @@ export class AssumeProfilePlugin implements Plugin {
       region?: string;
       assumeRoleName?: string;
       assumeRoleDuration?: number;
-      credentials?: AWS.STS.Credentials;
+      credentials?: Credentials;
       partition?: string;
       caBundlePath?: string;
     } = {},

--- a/source/packages/@aws-cdk-extensions/cdk-plugin-assume-role/package.json
+++ b/source/packages/@aws-cdk-extensions/cdk-plugin-assume-role/package.json
@@ -20,6 +20,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
+    "@aws-sdk/client-sts": "3.588.0",
     "@typescript-eslint/eslint-plugin": "5.53.0",
     "@typescript-eslint/parser": "5.53.0",
     "aws-cdk": "2.93.0",


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/462

*Description of changes:*
Attempts to migrate AWS SDK for JavaScript v2 APIs to v3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
