### PR TITLE
fix(construct): enforce dependancy to halt execution until ready

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
@@ -317,6 +317,9 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
     },
     "AccessAnalyzerServiceLinkedRoleCreateServiceLinkedRoleResource7C0C5637": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AccessAnalyzerServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup6DA63F2D",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -1337,6 +1340,9 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
     },
     "GuardDutyServiceLinkedRoleCreateServiceLinkedRoleResourceD5FE1FBD": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "GuardDutyServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup362E3CCE",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -1604,6 +1610,9 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
     },
     "MacieServiceLinkedRoleCreateServiceLinkedRoleResourceD2E64172": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "MacieServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup7DF41D83",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -1896,6 +1905,9 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
     },
     "SecurityHubServiceLinkedRoleCreateServiceLinkedRoleResource4CC7EFAA": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "SecurityHubServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupD9501DFE",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
@@ -261,6 +261,9 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 1`] = `
     },
     "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleResource5A765F9A": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleFunctionLogGroup3B94FCDE",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -1856,6 +1859,9 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 1`] = `
     },
     "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleResourceE203F878": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupAF98D208",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -4902,6 +4908,9 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 2`] = `
     },
     "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleResource5A765F9A": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleFunctionLogGroup3B94FCDE",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -5459,6 +5468,9 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 2`] = `
     },
     "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleResourceE203F878": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupAF98D208",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -9537,6 +9549,9 @@ exports[`LoggingStackOuTargets Construct(LoggingStackOuTargets):  Snapshot Test 
     },
     "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleResource5A765F9A": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AWSServiceRoleForAWSCloud9CreateServiceLinkedRoleFunctionLogGroup3B94FCDE",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -10859,6 +10874,9 @@ exports[`LoggingStackOuTargets Construct(LoggingStackOuTargets):  Snapshot Test 
     },
     "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleResourceE203F878": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "AutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupAF98D208",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/network-associations-gwlb-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/network-associations-gwlb-stack.test.ts.snap
@@ -2194,6 +2194,9 @@ exports[`NetworkAssociationsGwlbStack Construct(NetworkAssociationsGwlbStack):  
     },
     "NetworkInspectiontestAsgFirewallAsgAutoScalingServiceLinkedRoleCreateServiceLinkedRoleResource284D5F40": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "NetworkInspectiontestAsgFirewallAsgAutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupF88900CB",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
@@ -2475,6 +2475,9 @@ exports[`MultiOuOrganizationsStack Construct(OrganizationsStack):  Snapshot Test
     },
     "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleResourceE252DEA3": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup162E628B",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -5790,6 +5793,9 @@ exports[`OrganizationsStack Construct(OrganizationsStack):  Snapshot Test 1`] = 
     },
     "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleResourceE252DEA3": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup162E628B",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
@@ -9087,6 +9093,9 @@ exports[`delegatedAdminStack Construct(OrganizationsStack):  Snapshot Test 1`] =
     },
     "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleResourceE252DEA3": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "FirewallManagerServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup162E628B",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/pipeline-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/pipeline-stack.test.ts.snap
@@ -1162,6 +1162,9 @@ exports[`PipelineStack Construct(PipelineStack):  Snapshot Test 1`] = `
     },
     "PipelineAWSServiceRoleForCodeStarNotificationsCreateServiceLinkedRoleResource12D935F1": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "PipelineAWSServiceRoleForCodeStarNotificationsCreateServiceLinkedRoleFunctionLogGroup28940852",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/constructs/lib/aws-iam/service-linked-role.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-iam/service-linked-role.ts
@@ -76,7 +76,7 @@ export class ServiceLinkedRole extends Construct {
       environmentEncryption: props.environmentEncryptionKmsKey,
     });
 
-    new cdk.aws_logs.LogGroup(this, `${lambdaFunction.node.id}LogGroup`, {
+    const logGroup = new cdk.aws_logs.LogGroup(this, `${lambdaFunction.node.id}LogGroup`, {
       logGroupName: `/aws/lambda/${lambdaFunction.functionName}`,
       retention: props.cloudWatchLogRetentionInDays,
       encryptionKey: props.cloudWatchLogKmsKey,
@@ -97,6 +97,9 @@ export class ServiceLinkedRole extends Construct {
         uuid: uuidv4(), // Generates a new UUID to force the resource to update
       },
     });
+
+    // Ensure that the LogGroup is created by Cloudformation prior to Lambda execution
+    this.resource.node.addDependency(logGroup);
 
     this.roleArn = this.resource.getAtt('roleArn').toString();
     this.roleName = this.resource.getAtt('roleName').toString();

--- a/source/packages/@aws-accelerator/constructs/test/aws-autoscaling/__snapshots__/create-autoscaling-group.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-autoscaling/__snapshots__/create-autoscaling-group.test.ts.snap
@@ -322,6 +322,9 @@ exports[`AutoscalingGroup Construct(AutoscalingGroup):  Snapshot Test 1`] = `
     },
     "TestAutoScalingServiceLinkedRoleCreateServiceLinkedRoleResourceC5B197D4": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "TestAutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroup4DBD4D73",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/constructs/test/aws-ec2/__snapshots__/firewall-asg.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-ec2/__snapshots__/firewall-asg.test.ts.snap
@@ -295,6 +295,9 @@ exports[`LaunchTemplate Construct(FirewallAutoScalingGroup):  Snapshot Test 1`] 
     },
     "TestFirewallAutoScalingServiceLinkedRoleCreateServiceLinkedRoleResource1EB49BEA": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "TestFirewallAutoScalingServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupB0B4539B",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [

--- a/source/packages/@aws-accelerator/constructs/test/aws-iam/__snapshots__/service-linked-role.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-iam/__snapshots__/service-linked-role.test.ts.snap
@@ -295,6 +295,9 @@ exports[`ServiceLinkedRole Construct(ServiceLinkedRole):  Snapshot Test 1`] = `
     },
     "ServiceLinkedRoleCreateServiceLinkedRoleResource8BE1DC5C": {
       "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ServiceLinkedRoleCreateServiceLinkedRoleFunctionLogGroupE011C075",
+      ],
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [


### PR DESCRIPTION
*Issue #471 - blocking 1.7.0 upgrade*

*Description of changes:*

Summary of comment: https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/471#issuecomment-2153909442

Race condition between lambda executution and Cloudformation stack to create log group.
