### PR TITLE
Fix: parse error during stack diff

### DIFF
--- a/source/packages/@aws-accelerator/utils/lib/diff-stack.ts
+++ b/source/packages/@aws-accelerator/utils/lib/diff-stack.ts
@@ -47,8 +47,8 @@ export function printStackDiff(
   // detect and filter out mangled characters from the diff
   let filteredChangesCount = 0;
   if (diff.differenceCount && !strict) {
-    const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(newTemplate)));
-    const mangledDiff = fullDiff(oldTemplate, mangledNewTemplate, changeSet);
+    const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(readTemplate(newTemplate))));
+    const mangledDiff = fullDiff(readTemplate(oldTemplate), mangledNewTemplate, changeSet);
     filteredChangesCount = Math.max(0, diff.differenceCount - mangledDiff.differenceCount);
     if (filteredChangesCount > 0) {
       diff = mangledDiff;


### PR DESCRIPTION
Fix #597 

Bug introduced during [upgrade to CDK to 2.148](https://github.com/awslabs/landing-zone-accelerator-on-aws/commit/16ec0cc5add8a79c10cb07457cae6b9524e613ab#diff-a799deca78205b2a65ce95d7c6c69e705ba78e2bd1049fc5b6e3d43f7cb66a19)  [mangleLikeCloudFormation](https://github.com/aws/aws-cdk/blob/0a56c0db7e9851af26e65a05521e0ec082a06c9c/packages/%40aws-cdk/cloudformation-diff/lib/diff/util.ts#L154-L156) and [fullDiff](https://github.com/aws/aws-cdk/blob/0a56c0db7e9851af26e65a05521e0ec082a06c9c/packages/%40aws-cdk/cloudformation-diff/lib/diff-template.ts#L48-L53) requires the template content in JSON format instead of the file paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
