### PR TITLE
fix(constructs): service linked role missing permissions

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/accounts-stack.test.ts.snap
@@ -173,6 +173,7 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -1196,6 +1197,7 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -1466,6 +1468,7 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -2727,6 +2730,7 @@ exports[`AccountsStack us-east-1 Construct(AccountsStack):  Snapshot Test 1`] = 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/logging-stack.test.ts.snap
@@ -117,6 +117,7 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 1`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -1667,6 +1668,7 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 1`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -4773,6 +4775,7 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 2`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -5305,6 +5308,7 @@ exports[`LoggingStack Construct(LoggingStack):  Snapshot Test 2`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -9491,6 +9495,7 @@ exports[`LoggingStackOuTargets Construct(LoggingStackOuTargets):  Snapshot Test 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -10765,6 +10770,7 @@ exports[`LoggingStackOuTargets Construct(LoggingStackOuTargets):  Snapshot Test 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/network-associations-gwlb-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/network-associations-gwlb-stack.test.ts.snap
@@ -2065,6 +2065,7 @@ exports[`NetworkAssociationsGwlbStack Construct(NetworkAssociationsGwlbStack):  
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
@@ -1134,11 +1134,7 @@ exports[`OperationsStack Construct(OperationsStack):  Snapshot Test 1`] = `
       "Properties": {
         "Name": "/accelerator/AWSAccelerator-OperationsStack-111111111111-us-east-1/version",
         "Type": "String",
-<<<<<<< HEAD
         "Value": "1.11.0",
-=======
-        "Value": "1.10.1",
->>>>>>> d8fe87d61 (release/v1.10.1)
       },
       "Type": "AWS::SSM::Parameter",
     },

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
@@ -1134,7 +1134,11 @@ exports[`OperationsStack Construct(OperationsStack):  Snapshot Test 1`] = `
       "Properties": {
         "Name": "/accelerator/AWSAccelerator-OperationsStack-111111111111-us-east-1/version",
         "Type": "String",
+<<<<<<< HEAD
         "Value": "1.11.0",
+=======
+        "Value": "1.10.1",
+>>>>>>> d8fe87d61 (release/v1.10.1)
       },
       "Type": "AWS::SSM::Parameter",
     },

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/organizations-stack.test.ts.snap
@@ -2328,6 +2328,7 @@ exports[`MultiOuOrganizationsStack Construct(OrganizationsStack):  Snapshot Test
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -5752,6 +5753,7 @@ exports[`OrganizationsStack Construct(OrganizationsStack):  Snapshot Test 1`] = 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",
@@ -9069,6 +9071,7 @@ exports[`delegatedAdminStack Construct(OrganizationsStack):  Snapshot Test 1`] =
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/pipeline-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/pipeline-stack.test.ts.snap
@@ -1563,6 +1563,7 @@ exports[`PipelineStack Construct(PipelineStack):  Snapshot Test 1`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/constructs/lib/aws-iam/service-linked-role.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-iam/service-linked-role.ts
@@ -69,7 +69,7 @@ export class ServiceLinkedRole extends Construct {
       initialPolicy: [
         new cdk.aws_iam.PolicyStatement({
           effect: cdk.aws_iam.Effect.ALLOW,
-          actions: ['iam:CreateServiceLinkedRole', 'iam:GetRole'],
+          actions: ['iam:CreateServiceLinkedRole', 'iam:GetRole', 'lambda:GetFunction'],
           resources: ['*'],
         }),
       ],

--- a/source/packages/@aws-accelerator/constructs/test/aws-autoscaling/__snapshots__/create-autoscaling-group.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-autoscaling/__snapshots__/create-autoscaling-group.test.ts.snap
@@ -321,6 +321,7 @@ exports[`AutoscalingGroup Construct(AutoscalingGroup):  Snapshot Test 1`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/constructs/test/aws-ec2/__snapshots__/firewall-asg.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-ec2/__snapshots__/firewall-asg.test.ts.snap
@@ -293,6 +293,7 @@ exports[`LaunchTemplate Construct(FirewallAutoScalingGroup):  Snapshot Test 1`] 
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",

--- a/source/packages/@aws-accelerator/constructs/test/aws-iam/__snapshots__/service-linked-role.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-iam/__snapshots__/service-linked-role.test.ts.snap
@@ -262,6 +262,7 @@ exports[`ServiceLinkedRole Construct(ServiceLinkedRole):  Snapshot Test 1`] = `
               "Action": [
                 "iam:CreateServiceLinkedRole",
                 "iam:GetRole",
+                "lambda:GetFunction",
               ],
               "Effect": "Allow",
               "Resource": "*",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/629

*Description of changes:*

Adds permission that was required.

Note: Still issues with snapshots raised in https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/624 & attempted to be fixed https://github.com/awslabs/landing-zone-accelerator-on-aws/pull/611


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
