### PR TITLE
fix(#639): Honor current securityOU naming in manifestDocument org structure

### DIFF
--- a/source/packages/@aws-accelerator/lza-modules/lib/control-tower/index.ts
+++ b/source/packages/@aws-accelerator/lza-modules/lib/control-tower/index.ts
@@ -367,6 +367,7 @@ abstract class LandingZoneOperation {
       landingZoneConfiguration,
       'UPDATE',
       landingZoneDetails.kmsKeyArn,
+      landingZoneDetails.securityOuName,
       landingZoneDetails.sandboxOuName,
     );
 

--- a/source/packages/@aws-accelerator/lza-modules/lib/control-tower/utils/resources.ts
+++ b/source/packages/@aws-accelerator/lza-modules/lib/control-tower/utils/resources.ts
@@ -150,6 +150,7 @@ export type ControlTowerLandingZoneDetailsType = {
  * Function to make manifest document for CT API
  * @param landingZoneConfiguration ${@link LandingZoneConfigType}
  * @param event string 'CREATE' | 'UPDATE'
+ * @param securityOuName string
  * @param sandboxOuName string
  * @returns
  */
@@ -157,6 +158,7 @@ export function makeManifestDocument(
   landingZoneConfiguration: ControlTowerLandingZoneConfigType,
   event: 'CREATE' | 'UPDATE',
   kmsKeyArn?: string,
+  securityOuName?: string,
   sandboxOuName?: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
@@ -177,7 +179,7 @@ export function makeManifestDocument(
     if (sandboxOuName) {
       organizationStructure = {
         security: {
-          name: 'Security',
+          name: securityOuName ?? 'Security',
         },
         sandbox: {
           name: sandboxOuName,
@@ -186,7 +188,7 @@ export function makeManifestDocument(
     } else {
       organizationStructure = {
         security: {
-          name: 'Security',
+          name: securityOuName ?? 'Security',
         },
       };
     }


### PR DESCRIPTION
#639 

Honor the existing Security OU naming.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
