### PR TITLE
fix: add special macie principal in opt-in regions

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/logging-stack.ts
@@ -19,14 +19,14 @@ import { pascalCase } from 'pascal-case';
 import path from 'path';
 
 import {
+  AccessLogBucketConfig,
+  AseaResourceType,
+  AssetBucketConfig,
+  CentralLogBucketConfig,
+  CloudWatchLogsExclusionConfig,
+  ElbLogBucketConfig,
   SnsTopicConfig,
   VpcFlowLogsConfig,
-  CloudWatchLogsExclusionConfig,
-  CentralLogBucketConfig,
-  ElbLogBucketConfig,
-  AccessLogBucketConfig,
-  AssetBucketConfig,
-  AseaResourceType,
 } from '@aws-accelerator/config';
 import * as t from '@aws-accelerator/config/lib/common/types';
 import {
@@ -34,22 +34,22 @@ import {
   BucketEncryption,
   BucketEncryptionType,
   BucketPolicy,
+  BucketPolicyProps,
   BucketPrefix,
   BucketPrefixProps,
   BucketReplicationProps,
   CentralLogsBucket,
   CloudWatchDestination,
+  CloudWatchLogDataProtection,
   CloudWatchLogsSubscriptionFilter,
   CloudWatchToS3Firehose,
   KmsEncryption,
   NewCloudWatchLogEvent,
+  PutSsmParameter,
   S3PublicAccessBlock,
+  ServiceLinkedRole,
   SsmParameterLookup,
   ValidateBucket,
-  PutSsmParameter,
-  BucketPolicyProps,
-  ServiceLinkedRole,
-  CloudWatchLogDataProtection,
 } from '@aws-accelerator/constructs';
 
 import {
@@ -1513,6 +1513,16 @@ export class LoggingStack extends AcceleratorStack {
         principal: 'macie.amazonaws.com',
         accessType: BucketAccessType.READWRITE,
       });
+
+      for (const region of this.props.globalConfig.enabledRegions) {
+        if (OptInRegions.includes(region)) {
+          awsPrincipalAccesses.push({
+            name: `Macie-${region}`,
+            principal: `macie.${region}.amazonaws.com`,
+            accessType: BucketAccessType.READWRITE,
+          });
+        }
+      }
     }
 
     if (this.props.securityConfig.centralSecurityServices.guardduty.enable) {


### PR DESCRIPTION
For supporting opt-in regions, we need to add to the centralized s3 bucket KMS key resource-based policy, the following principal: "macie.{opt-in-region}.amazonaws.com". This grants permission to the KMS key to take actions on the s3 bucket content within an opt-in region.

The code I've added is pretty much straight forward, so I don't feel a need to elaborate on it. 
Thx in advance.