### PR TITLE
fix(uninstaller): correct syntax for debug log

### DIFF
--- a/source/packages/@aws-accelerator/tools/lib/classes/accelerator-tool.ts
+++ b/source/packages/@aws-accelerator/tools/lib/classes/accelerator-tool.ts
@@ -1120,7 +1120,7 @@ export class AcceleratorTool {
         if (e.name === 'KMSInvalidStateException') {
           // This is needed because session manager key is deleted with stack
           this.debugLog(
-            '`KMS Key ${kmsKeyId} from ${stackName} stack in ${keyStatus.KeyMetadata?.KeyState} status, can not schedule deletion`',
+            `KMS Key ${kmsKeyId} from ${stackName} stack in ${keyStatus.KeyMetadata?.KeyState} status, can not schedule deletion`,
             'info',
           );
           return true;


### PR DESCRIPTION
The additional single quotes don't allow the interpretation of the variables in the text
<img width="1488" alt="Screenshot 2024-12-05 at 4 19 11 pm" src="https://github.com/user-attachments/assets/dc007b40-61d9-4adc-9b1d-4d4db4e5781c">
