### PR TITLE
fix(logging): align cloudwatch firehose extension functionality with documentation

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/global-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/global-config.yaml
@@ -271,7 +271,7 @@ logging:
         categories:
           - Credentials
     firehose:
-      fileExtension: json.gz
+      fileExtension: .json.gz
     enable: true
     dynamicPartitioning: dynamic-partitioning/log-filters.json
     replaceLogDestinationArn: replaceLogDestinationArn

--- a/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/global-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/global-config.yaml
@@ -206,7 +206,7 @@ logging:
         categories:
           - Credentials
     firehose:
-      fileExtension: json.gz
+      fileExtension: .json.gz
     enable: true
     replaceLogDestinationArn: arn:aws:logs:us-east-1:111111111111:destination/log-destination
     dynamicPartitioning: dynamic-partitioning/log-filters.json

--- a/source/packages/@aws-accelerator/config/lib/models/global-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/models/global-config.ts
@@ -1091,9 +1091,9 @@ export interface ICloudWatchLogsExclusionConfig {
  * @example
  * ```
  * logging:
- *  - cloudwatchLogs:
- *  - firehose:
- *     - fileExtension: undefined | 'json.gz'
+ *   cloudwatchLogs:
+ *     firehose:
+ *       fileExtension: undefined | '.json.gz'
  *
  * ```
  */
@@ -1106,7 +1106,7 @@ export interface ICloudWatchFirehoseConfig {
    *
    * @example
    * ```
-   * - fileExtension: 'json.gz'
+   * fileExtension: '.json.gz'
    * ```
    *
    */
@@ -1167,6 +1167,8 @@ export interface ICloudWatchFirehoseConfig {
  *     deploymentTargets:
  *       organizationalUnits:
  *         - Root
+ *   firehose:
+ *     fileExtension: .json.gz
  * ```
  *
  */
@@ -1233,6 +1235,10 @@ export interface ICloudWatchLogsConfig {
    * CloudWatch Log data protection configuration
    */
   readonly dataProtection?: ICloudWatchDataProtectionConfig;
+  /**
+   * CloudWatch Firehose configuration
+   */
+  readonly firehose?: ICloudWatchFirehoseConfig
 }
 
 /**

--- a/source/packages/@aws-accelerator/config/validator/global-config-validator.ts
+++ b/source/packages/@aws-accelerator/config/validator/global-config-validator.ts
@@ -172,11 +172,6 @@ export class GlobalConfigValidator {
     this.validateS3ConfigDeploymentTargetAccounts(values, accountNames, errors);
 
     //
-    // Validate File Extensions
-    //
-    this.validateFileExtensions(values);
-
-    //
     // Validate region by region deploy order doesn't conflict with enabledRegions
     //
     this.validateRegionByRegionDeployOrderMatchesEnabledRegionsConfiguration(values, regionByRegionDeployOrder, errors);
@@ -1295,21 +1290,6 @@ export class GlobalConfigValidator {
           `Deployment target OU ${ou} for CloudWatch logs encryption does not exist in organization-config.yaml file.`,
         );
       }
-    }
-  }
-
-  /**
-   * Function to validate file extensions for firehose
-   * @param values
-   */
-  private validateFileExtensions(values: GlobalConfig) {
-    if (!values.logging.cloudwatchLogs?.firehose?.fileExtension) {
-      return;
-    }
-    const fileExtension = values.logging.cloudwatchLogs?.firehose?.fileExtension;
-    if (fileExtension.startsWith('.')) {
-      const logger = createLogger(['global-config-validator-file-extension']);
-      logger.warn(`Found file extension ${fileExtension} that starts with a dot.`);
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Documentation showed `firehose` as it's own property under `logging`. Implementation had it under `cloudwatch`. Updated comments/documentation to reflect. Properly added `ICloudWatchFirehoseConfig` to the `ICloudWatchLogsConfig` model. Removed testing for `.` prefix on file extension since it is required for functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
