### PR TITLE
fix: update global config schema to fix snsTopics declaration

### DIFF
--- a/source/packages/@aws-accelerator/config/lib/schemas/global-config.json
+++ b/source/packages/@aws-accelerator/config/lib/schemas/global-config.json
@@ -1432,6 +1432,9 @@
           "type": "array"
         }
       },
+      "required": [
+        "topics"
+      ],
       "type": "object"
     },
     "ISnsTopicConfig": {

--- a/source/packages/@aws-accelerator/config/lib/schemas/global-config.json
+++ b/source/packages/@aws-accelerator/config/lib/schemas/global-config.json
@@ -1433,6 +1433,7 @@
         }
       },
       "required": [
+        "deploymentTargets",
         "topics"
       ],
       "type": "object"


### PR DESCRIPTION
When validating the global config without snsTopics.topics defined, validation fails. There is no user friendly error message.
On the other side, if `snsTopics.topics` is defined but no `snsTopics.deploymentTargets`, the actions `Logging` & `Security_Resources` fail.

With this change, the users will get a better feedback how to fix the validation and avoid the pipeline to fail in subsequent actions.

*Issue #, if available:* https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/700

*Description of changes:* Update JSON Schema of global config to provide user friendly error on failed validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
