### PR TITLE
fix: consider enabling/disabling cloudtrail as reason to update the landing zone

### DIFF
--- a/source/packages/@aws-lza/common/functions.ts
+++ b/source/packages/@aws-lza/common/functions.ts
@@ -129,6 +129,7 @@ export async function getLandingZoneDetails(
             landingZoneDetails.accessLoggingBucketRetentionDays =
               value['configurations']['accessLoggingBucket']['retentionDays'];
             landingZoneDetails.kmsKeyArn = value['configurations']['kmsKeyArn'];
+            landingZoneDetails.enableOrganizationTrail = value['enabled'];
             break;
         }
       }

--- a/source/packages/@aws-lza/common/resources.ts
+++ b/source/packages/@aws-lza/common/resources.ts
@@ -156,6 +156,10 @@ export type ControlTowerLandingZoneDetailsType = {
    */
   sandboxOuName?: string;
   /**
+   * Flag indicating Organization level CloudTrail is enable or not.
+   */
+  enableOrganizationTrail?: boolean;
+  /**
    * Flag indicating weather AWS Control Tower sets up AWS account access with IAM Identity Center or not
    */
   enableIdentityCenterAccess?: boolean;

--- a/source/packages/@aws-lza/lib/control-tower/utils/resources.ts
+++ b/source/packages/@aws-lza/lib/control-tower/utils/resources.ts
@@ -217,6 +217,10 @@ export type ControlTowerLandingZoneDetailsType = {
    * AWS KMS CMK arn to encrypt AWS Control Tower Landing Zone resources
    */
   kmsKeyArn?: string;
+  /**
+   * Flag indicating Organization level CloudTrail is enable or not.
+   */
+  enableOrganizationTrail?: boolean;
 };
 
 /**
@@ -383,6 +387,11 @@ export function landingZoneUpdateOrResetRequired(
   if (landingZoneDetails.enableIdentityCenterAccess !== landingZoneConfiguration.enableIdentityCenterAccess) {
     reasons.push(
       `Changes made in EnableIdentityCenterAccess from ${landingZoneDetails.enableIdentityCenterAccess} to ${landingZoneConfiguration.enableIdentityCenterAccess}`,
+    );
+  }
+  if (landingZoneDetails.enableOrganizationTrail !== landingZoneConfiguration.enableOrganizationTrail) {
+    reasons.push(
+      `Changes made in EnableOrganizationTrail from ${landingZoneDetails.enableOrganizationTrail} to ${landingZoneConfiguration.enableOrganizationTrail}`,
     );
   }
 


### PR DESCRIPTION
*Issue https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/703

*Description of changes:*

Consider the configuration `controlTower.landingZone.logging.organizationTrail` in `global-config.yaml` as reason to update the ControlTower landing zone. 