### PR TITLE
feat(uninstallation): ignore accounts scheduled for closure

### DIFF
--- a/source/packages/@aws-accelerator/tools/lib/classes/accelerator-tool.ts
+++ b/source/packages/@aws-accelerator/tools/lib/classes/accelerator-tool.ts
@@ -53,7 +53,7 @@ import {
   KMSClient,
   ScheduleKeyDeletionCommand,
 } from '@aws-sdk/client-kms';
-import { ListAccountsCommand, OrganizationsClient } from '@aws-sdk/client-organizations';
+import { AccountStatus, ListAccountsCommand, OrganizationsClient } from '@aws-sdk/client-organizations';
 import {
   DeleteBucketCommand,
   DeleteObjectsCommand,
@@ -710,6 +710,10 @@ export class AcceleratorTool {
         organizationsClient.send(new ListAccountsCommand({ NextToken: nextToken })),
       );
       for (const account of page.Accounts ?? []) {
+        if (account.Status == AccountStatus.SUSPENDED) {
+          this.logger.error(`Account ${account.Name} (${account.Email}) is suspended, will not be cleaned up`);
+          continue;
+        }
         if (account.Id && account.Name) {
           accountIds.push({ accountName: account.Name, accountId: account.Id });
         }


### PR DESCRIPTION
Closes https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/727 

If accounts are `SUSPENDED`, uninstallation fails with the below:
~~~
2025-02-21 11:50:29.039 | info | accelerator-tool | Building stack list for: XXXXX in region us-east-1
AccessDenied: User: arn:aws:sts::YYYYYY:assumed-role/AWSReservedSSO_AWSAdministratorAccess_a32d1507e4705a0f/richard.keit.lza.2.sso is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::XXXXXXXX:role/AWSControlTowerExecution
    at throwDefaultError (/Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@smithy/smithy-client/dist-cjs/index.js:846:20)
    at /Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@smithy/smithy-client/dist-cjs/index.js:855:5
    at de_CommandError (/Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@aws-sdk/client-sts/dist-cjs/index.js:476:14)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async /Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20
    at async /Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@smithy/core/dist-cjs/index.js:165:18
    at async /Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@smithy/middleware-retry/dist-cjs/index.js:320:38
    at async /Users/richardkeit/git/versent/landing-zone-accelerator-on-aws/source/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22 {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 403,
    requestId: '30ac5f18-12c6-4fb2-b434-3dfd36c42fa8',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  Type: 'Sender',
  Code: 'AccessDenied'
}
~~~

The change will ignore accounts already slated for closure:

~~~
2025-02-21 11:52:13.544 | info | accelerator-tool | Reading file: reference/policies/iam-policies/platform-teams-policy.json
2025-02-21 11:52:14.811 | error | accelerator-tool | Account Testing-Workload (<account_email>) is suspended, will not be cleaned up
2025-02-21 11:52:14.812 | error | accelerator-tool | Account workloads-prod-public-website-prod (<account_email>) is suspended, will not be cleaned up
2025-02-21 11:52:14.812 | error | accelerator-tool | Account SharedServices (<account_email>) is suspended, will not be cleaned up
~~~ 