### PR TITLE
Permit key deletion if there are no aliases associated with the key

### DIFF
--- a/reference/sample-configurations/lza-sample-config/service-control-policies/guardrails-1.json
+++ b/reference/sample-configurations/lza-sample-config/service-control-policies/guardrails-1.json
@@ -148,6 +148,11 @@
             "alias/accelerator*"
           ]
         },
+        "Null": {
+          "kms:ResourceAliases": [
+            "false"
+          ]
+        },
         "ArnNotLike": {
           "aws:PrincipalARN": [
             "arn:${PARTITION}:iam::*:role/${ACCELERATOR_PREFIX}-*",


### PR DESCRIPTION
*Issue #, if available:*

#686 

*Description of changes:*

Added an IAM condition block so that there must be a resource alias present to deny key actions; otherwise, keys without aliases could be created but never deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
