### PR TITLE
fix(diagnostic-pack): use qualifier for external deployment

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/dependencies-stack/diagnostics-pack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/dependencies-stack/diagnostics-pack.ts
@@ -41,7 +41,7 @@ export class DiagnosticsPack {
     // Create diagnostic role in every account home region except management account for non external deployment
     if (isDiagnosticsPackEnabled && this.stack.region === props.globalConfig.homeRegion) {
       let diagnosticsPackLambdaRoleNamePrefix = props.prefixes.accelerator;
-      if (props.qualifier && props.qualifier !== 'aws-accelerator') {
+      if (props.qualifier) {
         diagnosticsPackLambdaRoleNamePrefix = props.qualifier;
       }
 


### PR DESCRIPTION
*Issue #, if available:*

#455

*Description of changes:*

`DiagnosticsPackLambdaRole` is created using the qualifier prefix as long as the qualifier is present. the `DiagnosticsPackAssumeRole` trust policy should reference the `DiagnosticsPackLambdaRole` role using the same prefix determining logic defined here:

https://github.com/awslabs/landing-zone-accelerator-on-aws/blob/79dda7f72363aef19819dc479e9b45d82be3b8a9/source/packages/@aws-accelerator/accelerator/lib/stacks/diagnostics-pack-stack.ts#L27

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
