### PR TITLE
fix(LogGroupEncryption): gracefully handle AWS InvalidParameterException for AWS Reserved

### DIFF
--- a/source/packages/@aws-accelerator/constructs/lib/aws-cloudwatch-logs/update-subscription-filter/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-cloudwatch-logs/update-subscription-filter/index.ts
@@ -583,7 +583,7 @@ async function updateLogGroupEncryption(logGroup: LogGroup, acceleratorLogKmsKey
         ),
       );
     } catch (error: any) {
-      if (error.name === 'InvalidParameterException' && error.message.includes('Log groups starting AWS/ are reserved for AWS')) {
+      if (error.name === 'InvalidParameterException' && error.message.includes('Log groups starting with AWS/ are reserved for AWS')) {
         console.warn(`Skipping encryption for log group ${logGroup.logGroupName} as it is an AWS managed log group`);
         return;
       }


### PR DESCRIPTION
Fixes #751 

Note: Rather than attempting to exclude the command with a known prefix - we decided to gracefully handle the failure on the AWS API.

The rationale was when testing, changing the KMS key for [aws-controltower/CloudTrailLogs](https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/aws-controltower$252FCloudTrailLogs) worked without issue.


