### PR TITLE
fix(pipeline): correct usage for qualifier in diffBucket url

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
@@ -1003,9 +1003,7 @@ export class AcceleratorPipeline extends Construct {
        */
       const reviewLink = `https://${cdk.Stack.of(this).region}.console.${this.getConsoleUrlSuffixForPartition(
         this.props.partition,
-      )}/s3/buckets/${this.props.prefixes.bucketName}-pipeline-${cdk.Stack.of(this).account}-${
-        cdk.Stack.of(this).region
-      }?prefix=AWSAccelerator-Pipel/Diffs/#{codepipeline.PipelineExecutionId}/&region=${
+      )}/s3/buckets/${this.pipeline.artifactBucket.bucketName}?prefix=AWSAccelerator-Pipel/Diffs/#{codepipeline.PipelineExecutionId}/&region=${
         cdk.Stack.of(this).region
       }&bucketType=general`;
 
@@ -1017,7 +1015,7 @@ export class AcceleratorPipeline extends Construct {
             runOrder: 2,
             additionalInformation: `
               Changes for this execution can be found in accelerator pipeline S3 bucket under Diffs/#{codepipeline.PipelineExecutionId}. 
-              Use cli command for download: "aws s3 sync ${this.diffS3Uri}/#{codepipeline.PipelineExecutionId} diffs" or follow the link below.`,
+              Use cli command for download: "aws s3 sync ${this.pipeline.artifactBucket.bucketName}/#{codepipeline.PipelineExecutionId} diffs" or follow the link below.`,
             notificationTopic,
             externalEntityLink: reviewLink,
             notifyEmails,

--- a/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
@@ -1003,7 +1003,9 @@ export class AcceleratorPipeline extends Construct {
        */
       const reviewLink = `https://${cdk.Stack.of(this).region}.console.${this.getConsoleUrlSuffixForPartition(
         this.props.partition,
-      )}/s3/buckets/${this.pipeline.artifactBucket.bucketName}?prefix=AWSAccelerator-Pipel/Diffs/#{codepipeline.PipelineExecutionId}/&region=${
+      )}/s3/buckets/${
+        this.pipeline.artifactBucket.bucketName
+      }?prefix=AWSAccelerator-Pipel/Diffs/#{codepipeline.PipelineExecutionId}/&region=${
         cdk.Stack.of(this).region
       }&bucketType=general`;
 
@@ -1015,7 +1017,7 @@ export class AcceleratorPipeline extends Construct {
             runOrder: 2,
             additionalInformation: `
               Changes for this execution can be found in accelerator pipeline S3 bucket under Diffs/#{codepipeline.PipelineExecutionId}. 
-              Use cli command for download: "aws s3 sync ${this.pipeline.artifactBucket.bucketName}/#{codepipeline.PipelineExecutionId} diffs" or follow the link below.`,
+              Use cli command for download: "aws s3 sync ${this.diffS3Uri}/#{codepipeline.PipelineExecutionId} diffs" or follow the link below.`,
             notificationTopic,
             externalEntityLink: reviewLink,
             notifyEmails,

--- a/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/pipeline.ts
@@ -220,6 +220,9 @@ export class AcceleratorPipeline extends Construct {
     let pipelineName = `${props.prefixes.accelerator}-Pipeline`;
     let buildProjectName = `${props.prefixes.accelerator}-BuildProject`;
     let toolkitProjectName = `${props.prefixes.accelerator}-ToolkitProject`;
+    this.diffS3Uri = `s3://${this.props.prefixes.bucketName}-pipeline-${cdk.Stack.of(this).account}-${
+      cdk.Stack.of(this).region
+    }/AWSAccelerator-Pipel/Diffs`;
 
     //
     // Change the fields when qualifier is present
@@ -233,6 +236,9 @@ export class AcceleratorPipeline extends Construct {
       pipelineName = `${this.props.qualifier}-pipeline`;
       buildProjectName = `${this.props.qualifier}-build-project`;
       toolkitProjectName = `${this.props.qualifier}-toolkit-project`;
+      this.diffS3Uri = `s3://${this.props.qualifier}-pipeline-${cdk.Stack.of(this).account}-${
+        cdk.Stack.of(this).region
+      }/AWSAccelerator-Pipel/Diffs`;
     }
 
     let nodeEnvVariables: { [p: string]: codebuild.BuildEnvironmentVariable } | undefined;
@@ -581,14 +587,11 @@ export class AcceleratorPipeline extends Construct {
     });
 
     /**
-     * Toolkit CodeBuild poroject is used to run all Accelerator stages, including diff
+     * Toolkit CodeBuild project is used to run all Accelerator stages, including diff
      * First it executes synth of all Pipeline stages and then diff within the same container.
      * CloudFormation templates are then reused for all further stages
-     * Diff files are uploaded to pipeline S3 bucket
+     * Diff files are uploaded to pipeline S3 bucket - consideration needed if running in external account
      */
-    this.diffS3Uri = `s3://${this.props.prefixes.bucketName}-pipeline-${cdk.Stack.of(this).account}-${
-      cdk.Stack.of(this).region
-    }/AWSAccelerator-Pipel/Diffs`;
 
     this.toolkitProject = new codebuild.PipelineProject(this, 'ToolkitProject', {
       projectName: toolkitProjectName,


### PR DESCRIPTION
closes #753

<img width="673" alt="image" src="https://github.com/user-attachments/assets/5b9fe697-6c2c-4e94-9c2f-b8ee5372ad4c" />


Worth also giving attention to (as I also disabled this to get the external deployment working):
- https://github.com/awslabs/landing-zone-accelerator-on-aws/pull/754