### PR TITLE
Fixes stack-policy in external deployment accounts

### DIFF
--- a/source/packages/@aws-accelerator/modules/bin/runner.ts
+++ b/source/packages/@aws-accelerator/modules/bin/runner.ts
@@ -43,7 +43,8 @@ async function main(): Promise<string> {
  */
 (async () => {
   try {
-    await main();
+    const status = await main();
+    statusLogger.info(status);
   } catch (err) {
     statusLogger.error(err);
     throw err;


### PR DESCRIPTION
Closes #829

~~~
2025-07-30 18:16:18.066 | info | index | Using existing credentials for account XXXXXXX in region ap-southeast-2
2025-07-30 18:16:18.298 | info | index | Set Stack Policy for stack AWSAccelerator-CustomizationsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.346 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkPrepStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.347 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkVpcEndpointsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.349 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkAssociationsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.351 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkVpcStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.353 | info | index | Set Stack Policy for stack AWSAccelerator-DiagnosticsPackStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.356 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkAssociationsGwlbStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.356 | info | index | Set Stack Policy for stack AWSAccelerator-KeyStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.368 | info | index | Set Stack Policy for stack AWSAccelerator-ResourcePolicyEnforcementStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.369 | info | index | Set Stack Policy for stack AWSAccelerator-NetworkVpcDnsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.376 | info | index | Set Stack Policy for stack AWSAccelerator-DependenciesStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.410 | info | index | Set Stack Policy for stack AWSAccelerator-OperationsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.423 | info | index | Set Stack Policy for stack AWSAccelerator-IdentityCenterStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.452 | info | index | Set Stack Policy for stack AWSAccelerator-SecurityResourcesStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.453 | info | index | Set Stack Policy for stack AWSAccelerator-CDKToolkit in region ap-southeast-2 to true
2025-07-30 18:16:18.478 | info | index | Set Stack Policy for stack AWSAccelerator-SecurityStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.479 | info | index | Set Stack Policy for stack AWSAccelerator-LoggingStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.493 | info | index | Set Stack Policy for stack AWSAccelerator-InstallerStack in region ap-southeast-2 to true
2025-07-30 18:16:18.497 | info | index | Set Stack Policy for stack AWSAccelerator-OrganizationsStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.508 | info | index | Set Stack Policy for stack AWSAccelerator-PipelineStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
2025-07-30 18:16:18.511 | info | index | Set Stack Policy for stack AWSAccelerator-PrepareStack-XXXXXXX-ap-southeast-2 in region ap-southeast-2 to true
~~~

Also removes this out of sorts logging - that is logged out of the module
<img width="1412" height="103" alt="Screenshot 2025-07-30 at 4 32 55 pm" src="https://github.com/user-attachments/assets/42a39caa-896a-413a-b33b-2023ad943072" />
