### PR TITLE
fix: missing s3 read permissions on accelerator metadata lambda role

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/security-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/security-stack.ts
@@ -464,6 +464,7 @@ export class SecurityStack extends AcceleratorStack {
       centralLogBucketName,
       configRepositoryLocation: acceleratorProps.configRepositoryLocation,
       configBucketName: `${this.props.qualifier}-config-${cdk.Stack.of(this).account}-${cdk.Stack.of(this).region}`,
+      secureBucketName: `${this.props.qualifier}-pipeline-${cdk.Stack.of(this).account}-${cdk.Stack.of(this).region}`,
       elbLogBucketName,
       cloudwatchKmsKey,
       loggingAccountId: acceleratorProps.accountsConfig.getAccountId(

--- a/source/packages/@aws-accelerator/constructs/lib/aws-accelerator/get-accelerator-metadata.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-accelerator/get-accelerator-metadata.ts
@@ -59,6 +59,10 @@ export interface AcceleratorMetadataProps {
    */
   readonly configBucketName: string;
   /**
+   * Secure bucket name
+   */
+  readonly secureBucketName: string;
+  /**
    * The Accelerator Organization Id
    */
   readonly organizationId: string;
@@ -117,6 +121,7 @@ export class AcceleratorMetadata extends Construct {
       region,
       props.metadataLogBucketName,
       props.configBucketName,
+      props.secureBucketName,
       configTableArn,
     );
     this.lambdaFunction = this.createLambdaFunction(functionName, stack, lambdaCode, this.role, props);
@@ -130,6 +135,7 @@ export class AcceleratorMetadata extends Construct {
     region: string,
     metadataLogBucketName: string,
     configBucketName: string,
+    secureBucketName: string,
     configTableArn: string,
   ) {
     const lambdaRole = new cdk.aws_iam.Role(this, 'MetadataLambda', {
@@ -182,6 +188,8 @@ export class AcceleratorMetadata extends Construct {
           `arn:${cdk.Stack.of(this).partition}:s3:::${metadataLogBucketName}/*`,
           `arn:${cdk.Stack.of(this).partition}:s3:::${configBucketName}`,
           `arn:${cdk.Stack.of(this).partition}:s3:::${configBucketName}/*`,
+          `arn:${cdk.Stack.of(this).partition}:s3:::${secureBucketName}`,
+          `arn:${cdk.Stack.of(this).partition}:s3:::${secureBucketName}/*`,
         ],
       }),
     );

--- a/source/packages/@aws-accelerator/constructs/test/aws-accelerator/__snapshots__/get-accelerator-metadata.test.ts.snap
+++ b/source/packages/@aws-accelerator/constructs/test/aws-accelerator/__snapshots__/get-accelerator-metadata.test.ts.snap
@@ -280,6 +280,30 @@ exports[`AcceleratorMetadata Construct(AcceleratorMetadata):  Snapshot Test 1`] 
                     ],
                   ],
                 },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::aws-accelerator-pipeline-111111111111-us-east-1",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::aws-accelerator-pipeline-111111111111-us-east-1/*",
+                    ],
+                  ],
+                },
               ],
             },
             {

--- a/source/packages/@aws-accelerator/constructs/test/aws-accelerator/get-accelerator-metadata.test.ts
+++ b/source/packages/@aws-accelerator/constructs/test/aws-accelerator/get-accelerator-metadata.test.ts
@@ -35,6 +35,7 @@ new AcceleratorMetadata(stack, 'AcceleratorMetadata', {
   globalRegion: 'us-east-1',
   configRepositoryLocation: 'codecommit',
   configBucketName: 'aws-accelerator-config-111111111111-us-east-1',
+  secureBucketName: 'aws-accelerator-pipeline-111111111111-us-east-1',
   installerStackName: 'AWSAccelerator-InstallerStack',
   accountOuConfigTableParameterPath: '/testPath',
   accountOuConfigTableArnParameterPath: '/testArnPath',


### PR DESCRIPTION
*Issue #, if available:* #864

*Description of changes:* Added S3 read permissions to accelerator metadata lambda execution role so it can read LZA config for those using a CodeConnections source.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.