### PR TITLE
fix: make email comparison case-insensitive in account validation

### DIFF
--- a/source/packages/@aws-lza/lib/control-tower/setup-landing-zone/prerequisites/organization.ts
+++ b/source/packages/@aws-lza/lib/control-tower/setup-landing-zone/prerequisites/organization.ts
@@ -294,7 +294,7 @@ export abstract class Organization {
     const accounts = await Organization.getOrganizationAccounts(client);
 
     for (const account of accounts) {
-      if (account.Id && account.Email === email) {
+      if (account.Id && account.Email.toLowerCase() === email.toLowerCase()) {
         return account;
       }
     }


### PR DESCRIPTION
*Description of changes:*
In the getOrganizationAccountDetailsByEmail function, updated the account email comparison logic to be case-insensitive by converting both email addresses to lowercase before comparison.

This change ensures that email comparisons work correctly regardless of casing differences between AWS Control Tower and the accounts-config.yaml file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
