### PR TITLE
enhance: allow the use of string lists in stack parameters in customizations-config

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/custom-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/custom-stack.ts
@@ -269,9 +269,9 @@ export function getStackDependencies(stackMappings: customStackMapping[]): custo
 
 function transformCfnParametersArrayToObject(
   parameters?: CfnParameter[],
-): { [parameterName: string]: string } | undefined {
+): { [parameterName: string]: string | string[] } | undefined {
   if (parameters) {
-    const parameterObject: { [key: string]: string } = {};
+    const parameterObject: { [key: string]: string | string[] } = {};
     for (const parameter of parameters) {
       parameterObject[parameter.name] = parameter.value;
     }

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/customizations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/customizations-stack.ts
@@ -94,7 +94,8 @@ export class CustomizationsStack extends AcceleratorStack {
         const templateUrl = this.getAssetUrl(stackSet.name, stackSet.template);
 
         const parameters = stackSet.parameters?.map(parameter => {
-          return { parameterKey: parameter.name, parameterValue: parameter.value };
+          const parameterValue = Array.isArray(parameter.value) ? parameter.value.join(',') : parameter.value;
+          return { parameterKey: parameter.name, parameterValue };
         });
 
         const operationPreferences: cdk.CfnStackSet.OperationPreferencesProperty = {

--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/cloudformation-templates/custom-s3-bucket.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/cloudformation-templates/custom-s3-bucket.yaml
@@ -8,10 +8,15 @@ Parameters:
     Description: A parameter passed as a dynamic lookup from SSM
     Type: String
     Default: ""
+  pListParameter:
+    Description: A parameter passed as a list of strings
+    Type: CommaDelimitedList
+    Default: ""
 Conditions:
   hasStringParameter: !Not [ !Equals [ !Ref pStringParameter, "" ]]
   hasDynamicParameter: !Not [ !Equals [ !Ref pDynamicParameter, "" ]]
-  hasParameters: !And [!Condition hasStringParameter, !Condition hasDynamicParameter]
+  hasListParameter: !Not [ !Equals [ !Join [ "", !Ref pListParameter ], "" ]]
+  hasParameters: !And [!Condition hasStringParameter, !Condition hasDynamicParameter, !Condition hasListParameter]
 Resources:
   LZACustomizationsBucket:
     Type: 'AWS::S3::Bucket'
@@ -53,3 +58,6 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub ${pDynamicParameter}-${pStringParameter}-topic
+      Tags:
+        - Key: ListValues
+          Value: !Join ["-", !Ref pListParameter]

--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/customizations-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/customizations-config.yaml
@@ -15,6 +15,10 @@ customizations:
           value: "test"
         - name: pDynamicParameter
           value: "{{resolve:ssm:/accelerator/lza-prefix}}"
+        - name: pListParameter
+          value:
+            - "value1"
+            - "value2"
     - deploymentTargets:
         organizationalUnits:
           - Security

--- a/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/cloudformation-templates/custom-s3-bucket.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/cloudformation-templates/custom-s3-bucket.yaml
@@ -8,10 +8,15 @@ Parameters:
     Description: A parameter passed as a dynamic lookup from SSM
     Type: String
     Default: ""
+  pListParameter:
+    Description: A parameter passed as a list of strings
+    Type: CommaDelimitedList
+    Default: ""
 Conditions:
   hasStringParameter: !Not [ !Equals [ !Ref pStringParameter, "" ]]
   hasDynamicParameter: !Not [ !Equals [ !Ref pDynamicParameter, "" ]]
-  hasParameters: !And [!Condition hasStringParameter, !Condition hasDynamicParameter]
+  hasListParameter: !Not [ !Equals [ !Join [ "", !Ref pListParameter ], "" ]]
+  hasParameters: !And [!Condition hasStringParameter, !Condition hasDynamicParameter, !Condition hasListParameter]
 Resources:
   LZACustomizationsBucket:
     Type: 'AWS::S3::Bucket'
@@ -54,3 +59,6 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub ${pDynamicParameter}-${pStringParameter}-topic
+      Tags:
+        - Key: ListValues
+          Value: !Join ["-", !Ref pListParameter]

--- a/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/customizations-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/customizations-config.yaml
@@ -15,6 +15,10 @@ customizations:
           value: "test"
         - name: pDynamicParameter
           value: "{{resolve:ssm:/accelerator/lza-prefix}}"
+        - name: pListParameter
+          value:
+            - "value1"
+            - "value2"
     - deploymentTargets:
         organizationalUnits:
           - Security

--- a/source/packages/@aws-accelerator/config/lib/common/types.ts
+++ b/source/packages/@aws-accelerator/config/lib/common/types.ts
@@ -487,12 +487,12 @@ export class OperationPreferences implements IOperationPreferences {
 
 export interface ICfnParameter {
   name: string;
-  value: string;
+  value: string | string[];
 }
 
 export class CfnParameter implements ICfnParameter {
   readonly name: string = '';
-  readonly value: string = '';
+  readonly value: string | string[] = '';
 }
 
 export type TrafficType = 'ALL' | 'ACCEPT' | 'REJECT';

--- a/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json
+++ b/source/packages/@aws-accelerator/config/lib/schemas/customizations-config.json
@@ -404,7 +404,17 @@
           "type": "string"
         },
         "value": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Allow the use of string lists in stack parameters in customizations-config

*Issue #599 *

*Description of changes:*
This allows a user to pass an array of strings as a cloudformation parameter in the customizations-config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
