### PR TITLE
fix: exclude invalid DynamoDB config entries

### DIFF
--- a/source/packages/@aws-accelerator/config/lib/organization-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/organization-config.ts
@@ -219,6 +219,13 @@ export class OrganizationConfig implements i.IOrganizationConfig {
       );
 
       const configOuNames = [...this.organizationalUnits.map(ou => ou.name), 'Root'];
+
+      // Check if the config table has invalid entries missing the orgInfo attribute.
+      if (organizationItems.length != organizationItems.filter(item => 'orgInfo' in item).length) {
+        logger.error(`DynamoDB table ${configTableName} has "organization" entries missing the "orgInfo" attribute.`);
+        throw new Error('configuration validation failed.');
+      }
+
       const allOrganizations = organizationItems.map(
         item => JSON.parse(item['orgInfo'] as string) as OrganizationalUnitIdConfig,
       );


### PR DESCRIPTION
*Issue #, if available:*

Issue #877

*Description of changes:*

The `AcceleratorConfigTable` can end up having invalid entries in it that do not have an `orgInfo` entry. This change shows a more descriptive error message to the user instead of complaining about trying to deserialize undefined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
