### PR TITLE
fix: apply global tags to Config Rules and CloudWatch Log Groups

### DIFF
--- a/source/packages/@aws-accelerator/constructs/lib/aws-cloudwatch-logs/create-log-groups/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-cloudwatch-logs/create-log-groups/index.ts
@@ -46,6 +46,9 @@ export async function handler(
   const owningAccountId: string | undefined = event.ResourceProperties['owningAccountId'];
   const owningRegion: string | undefined = event.ResourceProperties['owningRegion'];
   const roleName: string | undefined = event.ResourceProperties['roleName'];
+  const tags: Record<string, string> | undefined = event.ResourceProperties['tags']
+    ? JSON.parse(event.ResourceProperties['tags'])
+    : undefined;
   const invokingAccountId = event.ServiceToken.split(':')[4];
   const invokingRegion = event.ServiceToken.split(':')[3];
   const partition = event.ServiceToken.split(':')[1];
@@ -90,7 +93,7 @@ export async function handler(
       //
       // Code Block for CloudWatch Log Group if it doesn't exist
       else {
-        await createLogGroup(logClient, logGroupName, encryptionKey);
+        await createLogGroup(logClient, logGroupName, encryptionKey, tags);
       }
       //
       // Put log group retention policy
@@ -257,10 +260,16 @@ async function associateKey(logClient: CloudWatchLogsClient, kmsKeyId: string, l
  * @param logClient CloudWatchLogsClient
  * @param logGroupName string
  * @param kmsKeyId string | undefined
+ * @param tags Record<string, string> | undefined
  */
-async function createLogGroup(logClient: CloudWatchLogsClient, logGroupName: string, kmsKeyId?: string) {
+async function createLogGroup(
+  logClient: CloudWatchLogsClient,
+  logGroupName: string,
+  kmsKeyId?: string,
+  tags?: Record<string, string>,
+) {
   console.log(`Creating log group ${logGroupName}...`);
-  await throttlingBackOff(() => logClient.send(new CreateLogGroupCommand({ kmsKeyId, logGroupName })));
+  await throttlingBackOff(() => logClient.send(new CreateLogGroupCommand({ kmsKeyId, logGroupName, tags })));
 }
 
 /**

--- a/source/packages/@aws-accelerator/constructs/lib/aws-events/security-hub-event-log/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-events/security-hub-event-log/index.ts
@@ -31,9 +31,10 @@ export async function handler(event: CloudFormationCustomResourceEvent) {
     case 'Update':
       const logGroupName = event.ResourceProperties['logGroupName'];
       const logGroupArn = event.ResourceProperties['logGroupArn'];
+      const tags = event.ResourceProperties['tags'] ? JSON.parse(event.ResourceProperties['tags']) : undefined;
 
       // Create the log group /AWSAccelerator-SecurityHub (if a specified log group name wasn't provided) if it does not exist.
-      await createLogGroup(logGroupName);
+      await createLogGroup(logGroupName, tags);
       // Update resource policy
       await putLogGroupResourcePolicy(logGroupArn);
       return {
@@ -83,10 +84,10 @@ export async function generateResourcePolicy(logGroupArn: string) {
   });
 }
 
-export async function createLogGroup(logGroupName: string) {
+export async function createLogGroup(logGroupName: string, tags?: Record<string, string>) {
   try {
     console.log(`Attempting to create CloudWatch log group ${logGroupName}`);
-    await logsClient.send(new CreateLogGroupCommand({ logGroupName: logGroupName }));
+    await logsClient.send(new CreateLogGroupCommand({ logGroupName: logGroupName, tags }));
   } catch (e) {
     if (e instanceof ResourceAlreadyExistsException) {
       console.log(`Found existing CloudWatch log group ${logGroupName}, continuing`);

--- a/source/packages/@aws-accelerator/constructs/lib/aws-events/security-hub-events-log.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-events/security-hub-events-log.ts
@@ -48,6 +48,10 @@ export interface SecurityHubEventsLogProps {
    * Log Group Name
    */
   logGroupName?: string;
+  /**
+   * Tags to apply to the log group
+   */
+  tags?: Record<string, string>;
 }
 
 /**
@@ -66,7 +70,11 @@ export class SecurityHubEventsLog extends Construct {
       resource: {
         name: 'SecurityHubEventsFunction',
         parentId: id,
-        properties: [{ logGroupName: logGroupName }, { logGroupArn: logGroupArn }],
+        properties: [
+          { logGroupName: logGroupName },
+          { logGroupArn: logGroupArn },
+          ...(props.tags ? [{ tags: JSON.stringify(props.tags) }] : []),
+        ],
         forceUpdate: true,
       },
       lambda: {


### PR DESCRIPTION
***Issues, #907 & #891**

This PR ensures global tags and LZA accelerator tags are consistently applied to AWS Config Rules and CloudWatch Log Groups created by custom resources.

**Problem:**
Two related tagging issues were identified:
1. AWS Config Rules do not receive global tags or the LZA Accelerator tag, creating a security gap where rules can be modified/deleted without proper SCP controls
2. CloudWatch Log Groups created by custom resources (e.g., SecurityHub events) do not receive global tags

**Solution:**
This PR implements consistent tagging across both resource types:

**Config Rules (#907):**
- Modified `setupConfigServicesTagging()` in `security-resources-stack.ts` to include:
  - Global tags from `globalConfig.tags`
  - LZA Accelerator tag (`Accelerator: <prefix>`)
  - Rule-specific tags (which can override global tags)
- Ensures all Config Rules have proper tags for SCP-based access controls

**CloudWatch Log Groups (#891):**
- Updated `SecurityHubEventsLog` construct to pass tags to custom resource
- Enhanced `security-hub-event-log` lambda handler to accept and apply tags
- Enhanced `create-log-groups` lambda handler to accept and apply tags
- Modified `securityHubEventForwardToLogs()` to prepare and pass global + accelerator tags

**Files Changed:**
- `security-resources-stack.ts`: Config Rules tagging + SecurityHub log group tags
- `security-hub-events-log.ts`: Added tags property to interface and passed through
- `security-hub-event-log/index.ts`: Lambda handler accepts and applies tags
- `create-log-groups/index.ts`: Lambda handler accepts and applies tags

**Testing:**
- Code compiles without TypeScript errors
- Maintains backward compatibility (tags are optional)
- Existing behavior preserved when tags are not provided

**Benefits:**
- Closes security gap for Config Rules SCP controls
- Consistent tagging across all LZA-created resources
- Improved compliance and governance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.