### PR TITLE
fix/accelerator-metadata-lambda/identity-policy

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/security-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/security-stack.ts
@@ -463,8 +463,12 @@ export class SecurityStack extends AcceleratorStack {
       assumeRole: acceleratorProps.globalConfig.managementAccountAccessRole,
       centralLogBucketName,
       configRepositoryLocation: acceleratorProps.configRepositoryLocation,
-      configBucketName: `${this.props.qualifier}-config-${cdk.Stack.of(this).account}-${cdk.Stack.of(this).region}`,
-      secureBucketName: `${this.props.qualifier}-pipeline-${cdk.Stack.of(this).account}-${cdk.Stack.of(this).region}`,
+      configBucketName: `${this.props.prefixes.bucketName}-config-${cdk.Stack.of(this).account}-${
+        cdk.Stack.of(this).region
+      }`,
+      secureBucketName: `${this.props.prefixes.bucketName}-pipeline-${cdk.Stack.of(this).account}-${
+        cdk.Stack.of(this).region
+      }`,
       elbLogBucketName,
       cloudwatchKmsKey,
       loggingAccountId: acceleratorProps.accountsConfig.getAccountId(


### PR DESCRIPTION
**Issue #964**

*Description of changes:*
Rudimentary fix for the issue since I don't know the nuances of accelerator prefix versus accelerator qualifier. This changes the bucket ARNs being passed to the accelerator metadata stack to use accelerator bucket name prefix instead of accelerator qualifier. This fixes an identity policy error for users with ASEA -> LZA environments that aren't using the default qualifier of `aws-accelerator`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.