### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         run: unzip -o -q "./typedocs.zip" -d ${TYPEDOCS_DIR}
       - name: Install Python dependencies
         working-directory: ./source/mkdocs
-        run: pip install mkdocs==1.5.3 mkdocs-material==9.5.3 mike==2.0.0
+        run: pip install mkdocs==1.5.3 mkdocs-material==9.5.32 mike==2.0.0
       - name: Deploy docs
         working-directory: ./source/mkdocs
         run: |


### PR DESCRIPTION
Upgrades mkdocs-material dependency to >=9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.