### PR TITLE
feat(iam): add maxSessionDuration to roleSets.roles[]

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/asea-resources/iam-roles.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/asea-resources/iam-roles.ts
@@ -253,6 +253,9 @@ export class Roles extends AseaResource {
       resource.assumeRolePolicyDocument = this.getAssumeRolePolicy(roleItem);
       this.setResourceBoundaryPolicy(roleItem, resource);
       this.setInstanceProfile(roleItem, resource);
+      if (roleItem.maxSessionDuration !== undefined) {
+        resource.maxSessionDuration = roleItem.maxSessionDuration;
+      }
       this.scope.addSsmParameter({
         logicalId: pascalCase(`SsmParam${pascalCase(roleItem.name)}RoleArn`),
         parameterName: this.scope.getSsmPath(SsmResourceType.IAM_ROLE, [roleItem.name]),

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -486,6 +486,7 @@ export class OperationsStack extends AcceleratorStack {
       managedPolicies,
       path: roleSetItem.path,
       permissionsBoundary: this.policies[roleItem.boundaryPolicy],
+      maxSessionDuration: roleItem.maxSessionDuration ? cdk.Duration.seconds(roleItem.maxSessionDuration) : undefined,
     });
 
     // AwsSolutions-IAM4: The IAM user, role, or group uses AWS managed policies

--- a/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
+++ b/source/packages/@aws-accelerator/accelerator/test/__snapshots__/operations-stack.test.ts.snap
@@ -903,6 +903,7 @@ exports[`OperationsStack > Construct(OperationsStack):  Snapshot Test 1`] = `
             ],
           },
         ],
+        "MaxSessionDuration": 7200,
         "PermissionsBoundary": {
           "Ref": "DefaultBoundaryPolicy489A8D26",
         },

--- a/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/iam-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/all-enabled/iam-config.yaml
@@ -26,6 +26,7 @@ roleSets:
     roles:
       - name: EC2-Default-SSM-AD-Role
         instanceProfile: true
+        maxSessionDuration: 7200
         assumedBy:
           - type: service
             principal: ec2.amazonaws.com

--- a/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/iam-config.yaml
+++ b/source/packages/@aws-accelerator/accelerator/test/configs/snapshot-only/iam-config.yaml
@@ -21,6 +21,7 @@ roleSets:
     roles:
       - name: EC2-Default-SSM-AD-Role
         instanceProfile: true
+        maxSessionDuration: 7200
         assumedBy:
           - type: service
             principal: ec2.amazonaws.com

--- a/source/packages/@aws-accelerator/config/lib/iam-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/iam-config.ts
@@ -147,6 +147,7 @@ export class RoleConfig implements i.IRoleConfig {
   readonly boundaryPolicy: string = '';
   readonly name: string = '';
   readonly policies: PoliciesConfig | undefined = undefined;
+  readonly maxSessionDuration: number | undefined = undefined;
 }
 
 export class IdentityCenterConfig implements i.IIdentityCenterConfig {

--- a/source/packages/@aws-accelerator/config/lib/models/iam-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/models/iam-config.ts
@@ -901,6 +901,17 @@ export interface IRoleConfig {
    * @see {@link https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html | Permissions Boundaries}
    */
   readonly boundaryPolicy?: t.NonEmptyString;
+  /**
+   * The maximum session duration (in seconds) that you want to set for the role.
+   *
+   * @remarks
+   * This setting determines the maximum length of a session when assuming the role.
+   * Valid values range from 3600 seconds (1 hour) to 43200 seconds (12 hours).
+   * If not specified, AWS defaults to 3600 seconds.
+   *
+   * @see {@link https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html | CreateRole API}
+   */
+  readonly maxSessionDuration?: number;
 }
 
 /**

--- a/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json
+++ b/source/packages/@aws-accelerator/config/lib/schemas/iam-config.json
@@ -817,6 +817,10 @@
           "description": "Specifies whether to create an EC2 instance profile for this role.",
           "type": "boolean"
         },
+        "maxSessionDuration": {
+          "description": "The maximum session duration (in seconds) that you want to set for the role.",
+          "type": "number"
+        },
         "name": {
           "$ref": "#/definitions/NonEmptyString",
           "description": "The logical name for this IAM role. This name will be used as the role name in AWS IAM and can be referenced by other AWS resources and services."

--- a/source/packages/@aws-accelerator/config/validator/iam-config-validator.ts
+++ b/source/packages/@aws-accelerator/config/validator/iam-config-validator.ts
@@ -252,7 +252,7 @@ export class IamConfigValidator {
     //
     // Validate role names
     //
-    return this.validateRoleNames();
+    return [...this.validateRoleNames(), ...this.validateRoleMaxSessionDuration()];
   }
 
   /**
@@ -291,6 +291,32 @@ export class IamConfigValidator {
         });
       });
     });
+    return errors;
+  }
+
+  /**
+   * Validate maxSessionDuration values on roles
+   * @returns Array of validation errors
+   */
+  private validateRoleMaxSessionDuration(): string[] {
+    const errors: string[] = [];
+    for (const roleSet of this.iamConfig.roleSets ?? []) {
+      for (const role of roleSet.roles ?? []) {
+        if (role.maxSessionDuration !== undefined) {
+          if (!Number.isInteger(role.maxSessionDuration)) {
+            errors.push(`Role ${role.name} maxSessionDuration must be an integer, got ${role.maxSessionDuration}.`);
+          } else if (role.maxSessionDuration < 3600) {
+            errors.push(
+              `Role ${role.name} maxSessionDuration must be at least 3600 seconds, got ${role.maxSessionDuration}.`,
+            );
+          } else if (role.maxSessionDuration > 43200) {
+            errors.push(
+              `Role ${role.name} maxSessionDuration must be at most 43200 seconds, got ${role.maxSessionDuration}.`,
+            );
+          }
+        }
+      }
+    }
     return errors;
   }
 


### PR DESCRIPTION
*Issue #, if available:*

#1068

*Description of changes:*

Adds an optional `maxSessionDuration` property to `roleSets.roles[]` in the IAM configuration, allowing users to configure the maximum session duration (in seconds) for IAM roles created via LZA.

**Changes:**
- Added `maxSessionDuration` to the `IRoleConfig` interface and `RoleConfig` class
- Updated the JSON schema for `iam-config.json`
- Applied the property in `OperationsStack` (CDK role creation) and `iam-roles.ts` (ASEA-managed roles)
- Added config validation ensuring the value is an integer between 3600 and 43200
- Updated test configs and snapshots

This change has been successfully tested in my LZA deployment.

Human and AI collaborated on this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.