### PR TITLE
fix(identity-center): propagate errors so CFN reports FAILED on principal lookup miss

### DIFF
--- a/source/packages/@aws-accelerator/constructs/lib/aws-identity-center/build-identity-center-assignments/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-identity-center/build-identity-center-assignments/index.ts
@@ -76,113 +76,85 @@ export async function handler(event: CloudFormationCustomResourceEvent): Promise
   }
 
   async function onCreate(event: AWSLambda.CloudFormationCustomResourceCreateEvent) {
-    try {
-      // Build the account assignment creation
-      const assignmentCreationRequests = await buildCreateAssignmentsList(
-        accountIds,
-        principals,
-        identityStoreId,
-        instanceArn,
-        permissionSetArnValue,
-        principalType as PrincipalType,
-        principalId!,
-        idcClient,
-      );
+    // Errors must propagate so the CDK CustomResourceProvider runtime
+    // reports FAILED to CloudFormation. Returning { Status: 'FAILED' }
+    // here is silently ignored by the framework and surfaces as SUCCESS.
+    const assignmentCreationRequests = await buildCreateAssignmentsList(
+      accountIds,
+      principals,
+      identityStoreId,
+      instanceArn,
+      permissionSetArnValue,
+      principalType as PrincipalType,
+      principalId!,
+      idcClient,
+    );
 
-      if (assignmentCreationRequests.length > 0) {
-        await createAssignment(assignmentCreationRequests, ssoAdminClient);
-      }
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'SUCCESS',
-      };
-    } catch (error) {
-      console.error('Error creating Identity Center assignments:', error);
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'FAILED',
-        Reason: String(error),
-      };
+    if (assignmentCreationRequests.length > 0) {
+      await createAssignment(assignmentCreationRequests, ssoAdminClient);
     }
+    return {
+      PhysicalResourceId: event.LogicalResourceId,
+      Status: 'SUCCESS',
+    };
   }
 
   async function onUpdate(event: AWSLambda.CloudFormationCustomResourceUpdateEvent) {
-    try {
-      const previousAccountIdsList: string[] = event.OldResourceProperties['accountIds'] ?? [];
-      const deletionList = await retrieveAccountDeletions(previousAccountIdsList, accountIds);
-      // Build the account assignment creation
-      const assignmentCreationRequests = await buildCreateAssignmentsList(
-        accountIds,
-        principals,
-        identityStoreId,
-        instanceArn,
-        permissionSetArnValue,
-        principalType as PrincipalType,
-        principalId!,
-        idcClient,
-      );
+    const previousAccountIdsList: string[] = event.OldResourceProperties['accountIds'] ?? [];
+    const deletionList = await retrieveAccountDeletions(previousAccountIdsList, accountIds);
+    const assignmentCreationRequests = await buildCreateAssignmentsList(
+      accountIds,
+      principals,
+      identityStoreId,
+      instanceArn,
+      permissionSetArnValue,
+      principalType as PrincipalType,
+      principalId!,
+      idcClient,
+    );
 
-      if (assignmentCreationRequests.length > 0) {
-        await createAssignment(assignmentCreationRequests, ssoAdminClient);
-      }
-
-      const assignmentDeletionRequests = await buildDeleteAssignmentsList(
-        deletionList,
-        principals,
-        identityStoreId,
-        instanceArn,
-        permissionSetArnValue,
-        principalType as PrincipalType,
-        principalId!,
-        idcClient,
-      );
-
-      // Build the Delete Parameters
-      if (deletionList.length > 0) {
-        await deleteAssignment(assignmentDeletionRequests, ssoAdminClient);
-      }
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'SUCCESS',
-      };
-    } catch (error) {
-      console.error('Error updating Identity Center assignments:', error);
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'FAILED',
-        Reason: String(error),
-      };
+    if (assignmentCreationRequests.length > 0) {
+      await createAssignment(assignmentCreationRequests, ssoAdminClient);
     }
+
+    const assignmentDeletionRequests = await buildDeleteAssignmentsList(
+      deletionList,
+      principals,
+      identityStoreId,
+      instanceArn,
+      permissionSetArnValue,
+      principalType as PrincipalType,
+      principalId!,
+      idcClient,
+    );
+
+    if (deletionList.length > 0) {
+      await deleteAssignment(assignmentDeletionRequests, ssoAdminClient);
+    }
+    return {
+      PhysicalResourceId: event.LogicalResourceId,
+      Status: 'SUCCESS',
+    };
   }
 
   async function onDelete(event: AWSLambda.CloudFormationCustomResourceDeleteEvent) {
-    try {
-      const assignmentDeletionRequests = await buildDeleteAssignmentsList(
-        accountIds,
-        principals,
-        identityStoreId,
-        instanceArn,
-        permissionSetArnValue,
-        principalType as PrincipalType,
-        principalId!,
-        idcClient,
-      );
+    const assignmentDeletionRequests = await buildDeleteAssignmentsList(
+      accountIds,
+      principals,
+      identityStoreId,
+      instanceArn,
+      permissionSetArnValue,
+      principalType as PrincipalType,
+      principalId!,
+      idcClient,
+    );
 
-      // Call the delete account assignments method
-      await deleteAssignment(assignmentDeletionRequests, ssoAdminClient);
+    await deleteAssignment(assignmentDeletionRequests, ssoAdminClient);
 
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'SUCCESS',
-      };
-    } catch (error) {
-      console.error('Error deleting Identity Center assignments:', error);
-      return {
-        PhysicalResourceId: event.LogicalResourceId,
-        Status: 'FAILED',
-        Reason: String(error),
-      };
-    }
+    return {
+      PhysicalResourceId: event.LogicalResourceId,
+      Status: 'SUCCESS',
+    };
   }
 }
 

--- a/source/packages/@aws-accelerator/constructs/test/aws-identity-center/build-identity-center-assignments.test.ts
+++ b/source/packages/@aws-accelerator/constructs/test/aws-identity-center/build-identity-center-assignments.test.ts
@@ -151,7 +151,7 @@ describe('Build Identity Center Assignments - Principal ID Lookup', () => {
     expect(mockIdentityStoreClient.send).toHaveBeenCalledTimes(2);
   });
 
-  it('should return FAILED status when user lookup fails', async () => {
+  it('should reject when user lookup fails so the framework reports FAILED to CFN', async () => {
     mockIdentityStoreClient.send.mockRejectedValueOnce(new Error('ResourceNotFoundException'));
 
     const { handler } = await import('../../lib/aws-identity-center/build-identity-center-assignments/index.ts');
@@ -173,13 +173,12 @@ describe('Build Identity Center Assignments - Principal ID Lookup', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
-    const result = await handler(mockEvent);
-
-    expect(result?.Status).toBe('FAILED');
-    expect(result?.Reason).toContain("User 'nonexistent-user' not found in Identity Store 'd-906751796e'");
+    await expect(handler(mockEvent)).rejects.toThrow(
+      "User 'nonexistent-user' not found in Identity Store 'd-906751796e'",
+    );
   });
 
-  it('should return FAILED status when group lookup fails', async () => {
+  it('should reject when group lookup fails so the framework reports FAILED to CFN', async () => {
     mockIdentityStoreClient.send.mockRejectedValueOnce(new Error('ResourceNotFoundException'));
 
     const { handler } = await import('../../lib/aws-identity-center/build-identity-center-assignments/index.ts');
@@ -201,13 +200,12 @@ describe('Build Identity Center Assignments - Principal ID Lookup', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
-    const result = await handler(mockEvent);
-
-    expect(result?.Status).toBe('FAILED');
-    expect(result?.Reason).toContain("Group 'nonexistent-group' not found in Identity Store 'd-906751796e'");
+    await expect(handler(mockEvent)).rejects.toThrow(
+      "Group 'nonexistent-group' not found in Identity Store 'd-906751796e'",
+    );
   });
 
-  it('should return FAILED status for Update operations when principal lookup fails', async () => {
+  it('should reject on Update when principal lookup fails so the framework reports FAILED to CFN', async () => {
     mockIdentityStoreClient.send.mockRejectedValueOnce(new Error('ResourceNotFoundException'));
 
     const { handler } = await import('../../lib/aws-identity-center/build-identity-center-assignments/index.ts');
@@ -232,9 +230,6 @@ describe('Build Identity Center Assignments - Principal ID Lookup', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
-    const result = await handler(mockEvent);
-
-    expect(result?.Status).toBe('FAILED');
-    expect(result?.Reason).toContain("User 'invalid-user' not found in Identity Store 'd-906751796e'");
+    await expect(handler(mockEvent)).rejects.toThrow("User 'invalid-user' not found in Identity Store 'd-906751796e'");
   });
 });


### PR DESCRIPTION
*Issue #, if available:* #1088

*Description of changes:*

The Lambda backing `Custom::IdentityCenterAssignments` caught errors and returned `{ Status: 'FAILED', Reason: ... }` from inside its handler. The CDK `CustomResourceProvider` runtime ignores that return shape — it only treats a thrown/rejected handler as a failure — so CloudFormation received `SUCCESS` even when the user/group lookup failed in Identity Store.

Reporter's evidence (issue #1088):

```
ERROR  Error updating Identity Center assignments: Error: User 'dummy.user@example.com' not found in Identity Store 'd-0000000000': ResourceNotFoundException: USER not found.
INFO   submit response to cloudformation ... { Status: 'SUCCESS', Reason: "Error: User '...' not found ...", ... }
```

Because CloudFormation recorded the resource as successfully updated, subsequent deploys saw no property drift and skipped the resource entirely — leaving the assignment silently unapplied even after the missing user was created.

**Fix:** remove the catch blocks in `onCreate` / `onUpdate` / `onDelete` so the rejection propagates. The CDK provider runtime then correctly reports `FAILED` to CloudFormation with the original error reason. No behavior change on the success path.

Tests updated to assert the new contract (handler rejects on missing principal) instead of the previously-checked-but-ignored `Status` field on the return value.

**Note on base branch:** targeting `release/v1.15.1` since that is the repository's default branch and matches the pattern of recent contributor PRs. CONTRIBUTING.md says to target `main`, which was not entirely clear given that `main` is currently at v1.15.0 — happy to retarget if preferred.

**Note on CI:** the upstream `release/v1.15.1` branch currently has two unrelated CI failures that will surface on this PR — a prettier issue in `@aws-accelerator/modules/.../register-organizational-unit.ts:72` and the workflow `automated-tests.yml` running `yarn test` which doesn't exist (the script is `yarn test:unit`). Both predate this branch. Happy to send separate PRs for those.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.