### PR TITLE
fix(ci): repair Automated Tests workflow (Node 22, test:unit, prettier)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'yarn'
       - name: 'Build and Test'
         run: |
@@ -30,6 +30,6 @@ jobs:
           yarn install
           yarn lerna run precommit --stream
           yarn build
-          yarn test
+          yarn test:unit
         env:
           ACCELERATOR_PREFIX: AWSAccelerator

--- a/source/packages/@aws-accelerator/modules/lib/actions/control-tower/register-organizational-unit.ts
+++ b/source/packages/@aws-accelerator/modules/lib/actions/control-tower/register-organizational-unit.ts
@@ -69,8 +69,7 @@ export abstract class RegisterOrganizationalUnitModule {
       );
     }
 
-    const securityOuName =
-      params.moduleRunnerParameters.configs.accountsConfig.getAuditAccount().organizationalUnit;
+    const securityOuName = params.moduleRunnerParameters.configs.accountsConfig.getAuditAccount().organizationalUnit;
 
     const organizationalUnitsDetail = await getOrganizationalUnitsDetail({
       moduleName: params.moduleItem.name,


### PR DESCRIPTION
## Summary

The GitHub Actions \`Automated Tests\` workflow has been silently broken since late 2024 — three independent issues compound so that the job either fails immediately or never reaches a real test run. This PR fixes all three together so the workflow actually enforces what it claims to.

- **Bump \`setup-node\` from \`18.x\` → \`22.x\`.** Node 18 reached EOL on 2025-04-30 and is below the declared \`minimum: 20\` in \`source/package.json\` (\`config.node.version\`). Every other build system in the repo already uses 22: \`buildspec.yml:8\` (\`nodejs: 22\`), \`.gitlab-ci.yml:567\` (\`nodejs22\`), container Dockerfiles (\`nodejs22\`). Commit \`06e36b9f\` (\"chore: set default nodejs to 22\") updated those but missed the GitHub Actions workflow.
- **Rename \`yarn test\` → \`yarn test:unit\`.** Commit \`a68cecc8\` (2024-10-18, \"chore(test): add integration testing\") renamed the root \`test\` script to \`test:unit\` in \`source/package.json\` but didn't update the workflow. Since then, every CI run has errored with:
  > \`error Command \"test\" not found. Did you mean \"jest\"?\`
- **Fix pre-existing prettier violation in \`register-organizational-unit.ts\`.** Once Node bump + \`test:unit\` fix are in place, \`yarn lerna run precommit\` surfaces a prettier error at line 72:27 (\`Delete \\\`⏎·····\\\`\`). Joined the split assignment — stays under the 120-char \`printWidth\` declared in \`source/.prettierrc.json\`.

Why single PR: all three are pipeline-repair changes and landing them individually would leave CI red between merges.

## Validation

Validated end-to-end locally with [\`gh act\`](https://github.com/nektos/act) against \`catthehacker/ubuntu:custom-latest\`:

| Step | Node 18.x (before) | Node 22.x (after) |
|---|---|---|
| \`setup-node\` | ✅ installs 18.20.8 | ✅ installs 22.22.2 |
| \`yarn install\` | ✅ | ✅ |
| \`yarn lerna run precommit\` | ❌ prettier error (pre-existing) | ✅ 127 projects |
| \`yarn build\` | n/a | ✅ 127 projects |
| \`yarn test:unit\` | ❌ \`test\` script missing | ✅ 127 projects |
| **Total** | ❌ fails in under a minute | ✅ **Job succeeded** in 14m49s |

## Test plan
- [x] Workflow parses (\`gh act -l\`)
- [x] \`setup-node\` actually acquires Node 22.22.2 in the job
- [x] \`yarn install\` succeeds
- [x] \`yarn lerna run precommit --stream\` succeeds across all 127 projects
- [x] \`yarn build\` succeeds across all 127 projects
- [x] \`yarn test:unit\` succeeds across all 127 projects
- [ ] Workflow is green once merged and a PR triggers it on GitHub's hosted runners