### PR TITLE
fix()return automation assume role param when there are no params

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
@@ -1112,7 +1112,6 @@ export class SecurityResourcesStack extends AcceleratorStack {
     assumeRoleArn?: string[],
     configFunctionName?: string,
   ): RemediationParameters | undefined {
-
     const returnParams: RemediationParameters = {};
     if (assumeRoleArn) {
       returnParams['AutomationAssumeRole'] = {

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/security-resources-stack.ts
@@ -1112,9 +1112,6 @@ export class SecurityResourcesStack extends AcceleratorStack {
     assumeRoleArn?: string[],
     configFunctionName?: string,
   ): RemediationParameters | undefined {
-    if (!params) {
-      return undefined;
-    }
 
     const returnParams: RemediationParameters = {};
     if (assumeRoleArn) {
@@ -1123,6 +1120,10 @@ export class SecurityResourcesStack extends AcceleratorStack {
           Values: assumeRoleArn,
         },
       };
+    }
+
+    if (!params) {
+      return returnParams;
     }
 
     for (const param of params) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/871

*Description of changes:*

This fixes the issue with config remediation not having the AutomationAssumeRole if no parameters are defined in the configuration. 

This moves the null check after the assume role parameter is created, and then returns that parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
