### PR TITLE
fix(backup): Add the backup service role whenever backup vaults are created in accounts

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
@@ -125,7 +125,7 @@ export enum ServiceLinkedRoleType {
   FMS = 'fms',
   /**
    * AWS Backup SLR
-   */ 
+   */
   AWS_BACKUP = 'backup',
 }
 
@@ -549,18 +549,15 @@ export abstract class AcceleratorStack extends cdk.Stack {
     }
   }
 
-   /**
+  /**
    * Create Backup Service Linked role
    *
    * @remarks
    * Backup Service linked role is created when a backup vault is created, it is needed for cross account backups.
    */
   protected createBackupServiceLinkedRole(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
-    if (
-      this.props.globalConfig.backup &&
-      this.serviceLinkedRoleSupportedPartitionList.includes(this.props.partition)
-    ) {
-      this.createServiceLinkedRole(ServiceLinkedRoleType.BACKUP, {
+    if (this.props.globalConfig.backup && this.serviceLinkedRoleSupportedPartitionList.includes(this.props.partition)) {
+      this.createServiceLinkedRole(ServiceLinkedRoleType.AWS_BACKUP, {
         cloudwatch: key.cloudwatch,
         lambda: key.lambda,
       });
@@ -606,7 +603,6 @@ export abstract class AcceleratorStack extends cdk.Stack {
       });
     }
   }
-
 
   /**
    * Create Config Service Linked role

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
@@ -123,6 +123,10 @@ export enum ServiceLinkedRoleType {
    * AWS Firewall Manager SLR
    */
   FMS = 'fms',
+  /**
+   * AWS Backup SLR
+   */ 
+  AWS_BACKUP = 'backup',
 }
 
 /**
@@ -1108,6 +1112,16 @@ export abstract class AcceleratorStack extends cdk.Stack {
           cloudWatchLogKmsKey: key.cloudwatch,
           cloudWatchLogRetentionInDays: this.props.globalConfig.cloudwatchLogRetentionInDays,
           roleName: 'AWSServiceRoleForFMS',
+        });
+        break;
+      case ServiceLinkedRoleType.AWS_BACKUP:
+        this.logger.debug('Create BackupServiceLinkedRole');
+        serviceLinkedRole = new ServiceLinkedRole(this, 'BackupServiceLinkedRole', {
+          awsServiceName: 'backup.amazonaws.com',
+          environmentEncryptionKmsKey: key.lambda,
+          cloudWatchLogKmsKey: key.cloudwatch,
+          cloudWatchLogRetentionInDays: this.props.globalConfig.cloudwatchLogRetentionInDays,
+          roleName: 'AWSBackupDefaultServiceRole',
         });
         break;
       default:

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/accelerator-stack.ts
@@ -549,6 +549,65 @@ export abstract class AcceleratorStack extends cdk.Stack {
     }
   }
 
+   /**
+   * Create Backup Service Linked role
+   *
+   * @remarks
+   * Backup Service linked role is created when a backup vault is created, it is needed for cross account backups.
+   */
+  protected createBackupServiceLinkedRole(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
+    if (
+      this.props.globalConfig.backup &&
+      this.serviceLinkedRoleSupportedPartitionList.includes(this.props.partition)
+    ) {
+      this.createServiceLinkedRole(ServiceLinkedRoleType.BACKUP, {
+        cloudwatch: key.cloudwatch,
+        lambda: key.lambda,
+      });
+
+      this.nagSuppressionInputs.push({
+        id: NagSuppressionRuleIds.IAM4,
+        details: [
+          {
+            path: `${this.stackName}/BackupServiceLinkedRole/CreateServiceLinkedRoleFunction/ServiceRole/Resource`,
+            reason: 'Custom resource Lambda role policy.',
+          },
+        ],
+      });
+
+      this.nagSuppressionInputs.push({
+        id: NagSuppressionRuleIds.IAM5,
+        details: [
+          {
+            path: `${this.stackName}/BackupServiceLinkedRole/CreateServiceLinkedRoleFunction/ServiceRole/DefaultPolicy/Resource`,
+            reason: 'Custom resource Lambda role policy.',
+          },
+        ],
+      });
+
+      this.nagSuppressionInputs.push({
+        id: NagSuppressionRuleIds.IAM4,
+        details: [
+          {
+            path: `${this.stackName}/BackupServiceLinkedRole/CreateServiceLinkedRoleProvider/framework-onEvent/ServiceRole/Resource`,
+            reason: 'Custom resource Lambda role policy.',
+          },
+        ],
+      });
+
+      this.nagSuppressionInputs.push({
+        id: NagSuppressionRuleIds.IAM5,
+        details: [
+          {
+            path: `${this.stackName}/BackupServiceLinkedRole/CreateServiceLinkedRoleProvider/framework-onEvent/ServiceRole/DefaultPolicy/Resource`,
+            reason: 'Custom resource Lambda role policy.',
+          },
+        ],
+      });
+    }
+  }
+
+
   /**
    * Create Config Service Linked role
    *

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -154,7 +154,7 @@ export class OperationsStack extends AcceleratorStack {
     //
     // Backup Vaults
     //
-    this.addBackupVaults({ cloudwatch: this.cloudwatchKey, lambda: this.lambdaKey });
+    this.addBackupVaults();
 
     if (
       this.props.globalConfig.ssmInventory?.enable &&
@@ -782,12 +782,12 @@ export class OperationsStack extends AcceleratorStack {
    * Adds Backup Vaults as defined in the global-config.yaml. These Vaults can
    * be referenced in AWS Organizations Backup Policies
    */
-  private addBackupVaults(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
+  private addBackupVaults() {
     let backupKey: cdk.aws_kms.IKey | undefined = undefined;
     // Create backup service linked role
     this.createBackupServiceLinkedRole({
-      cloudwatch: key.cloudwatch,
-      lambda: key.lambda,
+      cloudwatch: this.cloudwatchKey,
+      lambda: this.lambdaKey,
     });
 
     for (const vault of this.props.globalConfig.backup?.vaults ?? []) {

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -784,8 +784,7 @@ export class OperationsStack extends AcceleratorStack {
    */
   private addBackupVaults(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
     let backupKey: cdk.aws_kms.IKey | undefined = undefined;
-
-    // Create backup service linked role in the event of cross account backups
+    // Create backup service linked role
     this.createBackupServiceLinkedRole({
       cloudwatch: key.cloudwatch,
       lambda: key.lambda,

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -81,6 +81,11 @@ export class OperationsStack extends AcceleratorStack {
   private cloudwatchKey: cdk.aws_kms.IKey | undefined;
 
   /**
+   * KMS Key used to encrypt custom resource Lambda environment variables, when undefined default AWS managed key will be used
+   */
+  private lambdaKey: cdk.aws_kms.IKey | undefined;
+
+  /**
    * KMS Key for central S3 Bucket
    */
   private centralLogsBucketKey: cdk.aws_kms.IKey;
@@ -98,6 +103,8 @@ export class OperationsStack extends AcceleratorStack {
     this.cloudwatchKey = this.getAcceleratorKey(AcceleratorKeyType.CLOUDWATCH_KEY);
 
     this.centralLogsBucketKey = this.getCentralLogsBucketKey(this.cloudwatchKey);
+
+    this.lambdaKey = this.getAcceleratorKey(AcceleratorKeyType.LAMBDA_KEY);
 
     //
     // Look up asset bucket KMS key
@@ -147,7 +154,7 @@ export class OperationsStack extends AcceleratorStack {
     //
     // Backup Vaults
     //
-    this.addBackupVaults();
+    this.addBackupVaults({ cloudwatch: this.cloudwatchKey, lambda: this.lambdaKey });
 
     if (
       this.props.globalConfig.ssmInventory?.enable &&
@@ -775,10 +782,17 @@ export class OperationsStack extends AcceleratorStack {
    * Adds Backup Vaults as defined in the global-config.yaml. These Vaults can
    * be referenced in AWS Organizations Backup Policies
    */
-  private addBackupVaults() {
+  private addBackupVaults(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
     let backupKey: cdk.aws_kms.IKey | undefined = undefined;
     for (const vault of this.props.globalConfig.backup?.vaults ?? []) {
       if (this.isIncluded(vault.deploymentTargets)) {
+
+        // Create backup service linked role in the event of cross account backups
+        this.createBackupServiceLinkedRole({
+          cloudwatch: key.cloudwatch,
+          lambda: key.lambda,
+        });
+
         // Only create the key if a vault is defined for this account
         if (backupKey === undefined) {
           backupKey = new cdk.aws_kms.Key(this, 'BackupKey', {

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/operations-stack.ts
@@ -784,15 +784,15 @@ export class OperationsStack extends AcceleratorStack {
    */
   private addBackupVaults(key: { cloudwatch?: cdk.aws_kms.IKey; lambda?: cdk.aws_kms.IKey }) {
     let backupKey: cdk.aws_kms.IKey | undefined = undefined;
+
+    // Create backup service linked role in the event of cross account backups
+    this.createBackupServiceLinkedRole({
+      cloudwatch: key.cloudwatch,
+      lambda: key.lambda,
+    });
+
     for (const vault of this.props.globalConfig.backup?.vaults ?? []) {
       if (this.isIncluded(vault.deploymentTargets)) {
-
-        // Create backup service linked role in the event of cross account backups
-        this.createBackupServiceLinkedRole({
-          cloudwatch: key.cloudwatch,
-          lambda: key.lambda,
-        });
-
         // Only create the key if a vault is defined for this account
         if (backupKey === undefined) {
           backupKey = new cdk.aws_kms.Key(this, 'BackupKey', {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/825

*Description of changes:*
Currently when backup vaults are provisioned in targeted accounts the service role for AWS Backup is not created. This can cause issues for AWS Backup that expects the service role, such as with copy actions. 

This PR will create the backup service role in any account where a backup vault is created. The current assumption is that this is not a user choice, as there are certain services in AWS Backup that use the service role. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
