### PR TITLE
fix(customizations): preserve Lambda env vars in customer CFN templates (fixes #643)

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/accelerator-aspects.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/accelerator-aspects.ts
@@ -15,6 +15,7 @@ import * as cdk from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
 import { version } from '../../../../package.json';
 import { createLogger, getGlobalRegion, getNodeVersion } from '@aws-accelerator/utils';
+import { CustomStack } from './stacks/custom-stack';
 
 const logger = createLogger(['accelerator-aspects']);
 /**
@@ -198,6 +199,14 @@ class AwsSolutionAspect implements cdk.IAspect {
   visit(node: IConstruct): void {
     if (node instanceof cdk.CfnResource) {
       if (node.cfnResourceType === 'AWS::Lambda::Function') {
+        // Skip Lambda functions defined in customer-provided customization templates.
+        // These are imported verbatim via CfnInclude in CustomStack, and injecting the
+        // SOLUTION_ID environment variable would modify customer code. It also breaks
+        // Lambda@Edge functions, which do not support environment variables.
+        // See https://github.com/awslabs/landing-zone-accelerator-on-aws/issues/643
+        if (cdk.Stack.of(node) instanceof CustomStack) {
+          return;
+        }
         node.addPropertyOverride('Environment.Variables.SOLUTION_ID', `AwsSolution/SO0199/${version}`);
       }
     }

--- a/source/packages/@aws-accelerator/accelerator/test/aspects.test.ts
+++ b/source/packages/@aws-accelerator/accelerator/test/aspects.test.ts
@@ -1,6 +1,19 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  AccountsConfig,
+  CustomizationsConfig,
+  GlobalConfig,
+  IamConfig,
+  NetworkConfig,
+  OrganizationConfig,
+  SecurityConfig,
+} from '@aws-accelerator/config';
 import { AcceleratorAspects, LambdaDefaultMemoryAspect, PermissionsBoundaryAspect } from '../lib/accelerator-aspects';
+import { CustomStack } from '../lib/stacks/custom-stack';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, test } from 'vitest';
 
 describe('AcceleratorAspects', () => {
@@ -219,6 +232,93 @@ describe('AcceleratorAspects', () => {
       template.hasResourceProperties('AWS::Lambda::Function', {
         MemorySize: 1024,
       });
+    });
+  });
+
+  describe('AwsSolutionAspect', () => {
+    test('should add SOLUTION_ID environment variable to LZA-managed Lambda functions', () => {
+      // GIVEN
+      new cdk.aws_lambda.Function(stack, 'TestFunction', {
+        runtime: cdk.aws_lambda.Runtime.NODEJS_20_X,
+        handler: 'index.handler',
+        code: cdk.aws_lambda.Code.fromInline('exports.handler = function() { }'),
+      });
+
+      // WHEN
+      new AcceleratorAspects(app, 'aws', false);
+
+      // THEN
+      template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Environment: {
+          Variables: {
+            SOLUTION_ID: Match.stringLikeRegexp('AwsSolution/SO0199/.*'),
+          },
+        },
+      });
+    });
+
+    test('should not modify Lambda functions defined in a customization CustomStack (issue #643)', () => {
+      // GIVEN - a customer customization template imported verbatim via CfnInclude
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lza-aspect-test-'));
+      const templateFile = 'lambda-edge.yaml';
+      fs.writeFileSync(
+        path.join(tmpDir, templateFile),
+        [
+          "AWSTemplateFormatVersion: '2010-09-09'",
+          'Resources:',
+          '  HelloWorldLambdaFunction:',
+          '    Type: AWS::Lambda::Function',
+          '    Properties:',
+          '      Handler: index.lambda_handler',
+          '      Role: arn:aws:iam::111111111111:role/edge-role',
+          '      Runtime: python3.12',
+          '      Code:',
+          '        ZipFile: |',
+          '          def lambda_handler(event, context):',
+          "              return 'Hello, World!'",
+          '',
+        ].join('\n'),
+      );
+
+      const customStack = new CustomStack(app, 'TestCustomStack', {
+        env: { account: '111111111111', region: 'us-east-1' },
+        configDirPath: tmpDir,
+        accountsConfig: new AccountsConfig({
+          managementAccountEmail: 'management@example.com',
+          logArchiveAccountEmail: 'logArchive@example.com',
+          auditAccountEmail: 'audit@example.com',
+        }),
+        globalConfig: new GlobalConfig({
+          homeRegion: 'us-east-1',
+          controlTower: { enable: false },
+          managementAccountAccessRole: 'AWSControlTowerExecution',
+        }),
+        iamConfig: new IamConfig(),
+        networkConfig: new NetworkConfig(),
+        organizationConfig: new OrganizationConfig(),
+        securityConfig: new SecurityConfig(),
+        customizationsConfig: new CustomizationsConfig(),
+        partition: 'aws',
+        centralizedLoggingRegion: 'us-east-1',
+        runOrder: 1,
+        stackName: 'TestCustomStack',
+        templateFile,
+        terminationProtection: false,
+        ssmParamNamePrefix: '/accelerator',
+      });
+
+      // WHEN
+      new AcceleratorAspects(app, 'aws', false);
+
+      // THEN - the customer Lambda must be left untouched (no Environment/SOLUTION_ID injected)
+      const customTemplate = Template.fromStack(customStack);
+      customTemplate.hasResourceProperties('AWS::Lambda::Function', {
+        Handler: 'index.lambda_handler',
+        Environment: Match.absent(),
+      });
+
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     });
   });
 


### PR DESCRIPTION
## Issue

Fixes #643

## Problem

The app-wide `AwsSolutionAspect` (`accelerator-aspects.ts`) unconditionally injects an `Environment.Variables.SOLUTION_ID` property into **every** `AWS::Lambda::Function` in the CDK tree.

Customization CloudFormation stacks (`CustomStack`) import the customer's template verbatim via `CfnInclude`, so the customer's own Lambda functions become CfnResources that the aspect then mutates. This:

1. Modifies customer-provided code, which the user did not ask for, and
2. Breaks **Lambda@Edge** functions, which [do not support environment variables](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-edge-function-restrictions.html#lambda-at-edge-restrictions-features).

The reporter confirmed the issue still reproduces on v1.15.5.

## Fix

Skip the `SOLUTION_ID` injection when the Lambda's owning stack is a `CustomStack` (i.e. a customer-provided customization template). LZA-authored Lambdas still receive the `SOLUTION_ID` user-agent value for usage tracking; customer customization templates are now left untouched.

The check uses the owning stack type rather than a name/description heuristic, so it precisely targets customer customization templates only.

## Tests

Added two cases to `test/aspects.test.ts` under a new `AwsSolutionAspect` describe block:

- LZA-managed Lambda functions still get `SOLUTION_ID` injected.
- Lambda functions defined in a customization `CustomStack` are left untouched (no `Environment` block added). This test fails without the fix and passes with it.

All 31 aspect tests pass; `tsc --noEmit` and `eslint` are clean. The `customizations-stack` snapshot tests are unaffected (they cover the stacksets/applications path, not `CustomStack`).