### PR TITLE
feat: Add AWS account tagging support via accounts-config.yaml

### DIFF
--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
@@ -19,6 +19,7 @@ import {
   IdentityCenterPermissionSetConfig,
 } from '@aws-accelerator/config';
 import {
+  AccountTag,
   AuditManagerOrganizationAdminAccount,
   Bucket,
   BucketEncryptionType,
@@ -192,6 +193,11 @@ export class OrganizationsStack extends AcceleratorStack {
     // Tagging Policies Config
     //
     this.addTaggingPolicies();
+
+    //
+    // Account Tags Config
+    //
+    this.addAccountTags();
 
     //
     // Create NagSuppressions
@@ -932,5 +938,38 @@ export class OrganizationsStack extends AcceleratorStack {
     }
 
     organizationsTrail.node.addDependency(enableCloudtrailServiceAccess);
+  }
+
+  /**
+   * Function to add account tags to all accounts that have tags configured
+   */
+  private addAccountTags() {
+    this.logger.info('Processing account tags configuration');
+
+    const allAccounts = this.stackProperties.accountsConfig.getAccounts();
+
+    for (const account of allAccounts) {
+      // Check if account has tags defined
+      if (account.tags && account.tags.length > 0) {
+        this.logger.info(`Adding tags to account: ${account.name}`);
+
+        // Get account ID
+        const accountId = this.stackProperties.accountsConfig.getAccountId(account.name);
+
+        // Convert tags to key-value object
+        const tags: { [key: string]: string } = {};
+        for (const tag of account.tags) {
+          tags[tag.key] = tag.value;
+        }
+
+        // Create AccountTag resource
+        new AccountTag(this, `AccountTag${account.name}`, {
+          accountId,
+          tags,
+          kmsKey: this.cloudwatchKey,
+          logRetentionInDays: this.logRetention,
+        });
+      }
+    }
   }
 }

--- a/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
+++ b/source/packages/@aws-accelerator/accelerator/lib/stacks/organizations-stack.ts
@@ -172,6 +172,11 @@ export class OrganizationsStack extends AcceleratorStack {
 
       // Enable GuardDuty Service Access
       this.enableGuardDutyServiceAccess();
+
+      //
+      // Account Tags Config
+      //
+      this.addAccountTags();
     }
 
     // Macie Configuration
@@ -193,11 +198,6 @@ export class OrganizationsStack extends AcceleratorStack {
     // Tagging Policies Config
     //
     this.addTaggingPolicies();
-
-    //
-    // Account Tags Config
-    //
-    this.addAccountTags();
 
     //
     // Create NagSuppressions

--- a/source/packages/@aws-accelerator/config/lib/accounts-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/accounts-config.ts
@@ -28,6 +28,7 @@ import {
 } from '@aws-accelerator/utils';
 import { createSchema, DeploymentTargets, parseAccountsConfig } from './common';
 import * as i from './models/accounts-config';
+import * as t from './common/types';
 import { OrganizationalUnitConfig } from './organization-config';
 import { Account } from '@aws-sdk/client-organizations';
 import { removeDuplicates, safeParseJsonProperty } from './common/config-helper';
@@ -48,6 +49,7 @@ export class AccountConfig implements i.IAccountConfig {
   readonly organizationalUnit: string = '';
   readonly warm: boolean | undefined = undefined;
   readonly accountAlias?: string | undefined = undefined;
+  readonly tags?: t.ITag[] | undefined = undefined;
 }
 
 export class GovCloudAccountConfig implements i.IGovCloudAccountConfig {
@@ -59,6 +61,7 @@ export class GovCloudAccountConfig implements i.IGovCloudAccountConfig {
   readonly warm: boolean | undefined = undefined;
   readonly enableGovCloud: boolean | undefined = undefined;
   readonly accountAlias?: string | undefined = undefined;
+  readonly tags?: t.ITag[] | undefined = undefined;
 }
 
 export class AccountsConfig implements i.IAccountsConfig {

--- a/source/packages/@aws-accelerator/config/lib/models/accounts-config.ts
+++ b/source/packages/@aws-accelerator/config/lib/models/accounts-config.ts
@@ -478,6 +478,45 @@ export interface IAccountConfig extends IBaseAccountConfig {
    * @default false
    */
   warm?: boolean;
+
+  /**
+   * **Account Tags** *(Optional)*
+   *
+   * Array of AWS resource tags to apply to the account. These tags will be applied
+   * using the AWS Organizations TagResource API when the account is created or updated.
+   *
+   * ### Tag Management
+   *
+   * - Tags are applied during account creation and updates
+   * - Changes to tags in the configuration will update the account tags
+   * - Removing tags from configuration will remove them from the account
+   * - Tags follow AWS Organizations tagging limits and restrictions
+   *
+   * ### Best Practices
+   *
+   * ```yaml
+   * tags:
+   *   - key: Environment
+   *     value: Production
+   *   - key: CostCenter
+   *     value: Engineering
+   *   - key: Owner
+   *     value: platform-team@company.com
+   *   - key: Project
+   *     value: CustomerPortal
+   * ```
+   *
+   * ### AWS Organizations Tag Limits
+   *
+   * - Maximum 50 tags per account
+   * - Tag keys can be up to 128 characters
+   * - Tag values can be up to 256 characters
+   * - Tag keys and values are case sensitive
+   * - Cannot start with "aws:" (reserved prefix)
+   *
+   * @see {@link https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tagging.html | AWS Organizations Tagging}
+   */
+  tags?: t.ITag[];
 }
 
 /**
@@ -589,6 +628,37 @@ export interface IGovCloudAccountConfig extends IBaseAccountConfig {
    * @default false
    */
   warm?: boolean;
+
+  /**
+   * **Account Tags** *(Optional)*
+   *
+   * Array of AWS resource tags to apply to the GovCloud account. These tags will be applied
+   * using the AWS Organizations TagResource API when the account is created or updated.
+   *
+   * ### GovCloud Tag Considerations
+   *
+   * - Tags are applied to both GovCloud and commercial partition accounts when enableGovCloud is true
+   * - GovCloud accounts may have additional compliance requirements for tag values
+   * - Consider data classification requirements in tag values
+   * - Follow agency-specific tagging standards for compliance
+   *
+   * ### Best Practices for GovCloud
+   *
+   * ```yaml
+   * tags:
+   *   - key: Environment
+   *     value: Production-GovCloud
+   *   - key: Classification
+   *     value: CUI
+   *   - key: ComplianceFramework
+   *     value: FedRAMP-High
+   *   - key: Agency
+   *     value: DepartmentOfDefense
+   * ```
+   *
+   * @see {@link https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tagging.html | AWS Organizations Tagging}
+   */
+  tags?: t.ITag[];
 }
 
 /**

--- a/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json
+++ b/source/packages/@aws-accelerator/config/lib/schemas/accounts-config.json
@@ -43,6 +43,13 @@
           "default": false,
           "description": "**Account Warming** *(Optional)*\n\nPre-provision the account by creating a temporary EC2 instance that runs for 15 minutes. This prepares the account's EC2 service for immediate production workload deployment.\n\n### When to Enable\n\n- **Enable** for accounts that will immediately deploy EC2-based workloads\n- **Enable** for production accounts requiring rapid deployment capabilities\n- **Disable** for accounts primarily using serverless or managed services\n- **Disable** for cost-sensitive development/testing environments\n\n### Process Details\n\n- Warming occurs during the operations stack deployment phase\n- Creates a minimal EC2 instance in the default VPC\n- Instance automatically terminates after 15 minutes\n- No additional charges beyond the brief EC2 usage\n- Can be safely removed from configuration after initial deployment\n\n### Best Practices\n\n```yaml # Production accounts - enable warming warm: true\n\n# Development/testing - typically disable warm: false\n\n# Serverless-only accounts - disable warm: false ```",
           "type": "boolean"
+        },
+        "tags": {
+          "description": "**Account Tags** *(Optional)*\n\nArray of AWS resource tags to apply to the account. These tags will be applied using the AWS Organizations TagResource API when the account is created or updated.\n\n### Tag Management\n\n- Tags are applied during account creation and updates\n- Changes to tags in the configuration will update the account tags\n- Removing tags from configuration will remove them from the account\n- Tags follow AWS Organizations tagging limits and restrictions\n\n### Best Practices\n\n```yaml tags:\n  - key: Environment\n    value: Production\n  - key: CostCenter\n    value: Engineering\n  - key: Owner\n    value: platform-team@company.com\n  - key: Project\n    value: CustomerPortal ```\n\n### AWS Organizations Tag Limits\n\n- Maximum 50 tags per account\n- Tag keys can be up to 128 characters\n- Tag values can be up to 256 characters\n- Tag keys and values are case sensitive\n- Cannot start with \"aws:\" (reserved prefix)",
+          "items": {
+            "$ref": "#/definitions/ITag"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -160,6 +167,13 @@
           "default": false,
           "description": "**Account Warming** *(Optional)*\n\nPre-provision the account by creating a temporary EC2 instance that runs for 15 minutes. This prepares the account's EC2 service for immediate production workload deployment in the GovCloud partition.\n\n### GovCloud Warming Considerations\n\n- Warming occurs in the GovCloud partition specifically\n- May take longer due to additional GovCloud provisioning requirements\n- Helps establish baseline EC2 service readiness for compliance workloads\n- Particularly beneficial for time-sensitive government deployments\n\n### Best Practices\n\n```yaml # Critical government workloads - enable warming warm: true\n\n# Development/testing in GovCloud - typically disable warm: false\n\n# Serverless-only GovCloud accounts - disable warm: false ```",
           "type": "boolean"
+        },
+        "tags": {
+          "description": "**Account Tags** *(Optional)*\n\nArray of AWS resource tags to apply to the GovCloud account. These tags will be applied using the AWS Organizations TagResource API when the account is created or updated.\n\n### GovCloud Tag Considerations\n\n- Tags are applied to both GovCloud and commercial partition accounts when enableGovCloud is true\n- GovCloud accounts may have additional compliance requirements for tag values\n- Consider data classification requirements in tag values\n- Follow agency-specific tagging standards for compliance\n\n### Best Practices for GovCloud\n\n```yaml tags:\n  - key: Environment\n    value: Production-GovCloud\n  - key: Classification\n    value: CUI\n  - key: ComplianceFramework\n    value: FedRAMP-High\n  - key: Agency\n    value: DepartmentOfDefense ```",
+          "items": {
+            "$ref": "#/definitions/ITag"
+          },
+          "type": "array"
         }
       },
       "required": [
@@ -173,6 +187,25 @@
       "minLength": 1,
       "pattern": "^[^\\s]*$",
       "type": "string"
+    },
+    "ITag": {
+      "additionalProperties": false,
+      "description": "## AWS Resource Tag Configuration\n\nDefines key-value pairs used for tagging AWS resources. Tags provide metadata for resource organization, cost allocation, access control, and automation.\n\n### Key Features\n\n- **Resource Organization**: Group and categorize resources logically\n- **Cost Allocation**: Track costs by project, department, or environment\n- **Access Control**: Use tags in IAM policies for conditional access\n- **Automation**: Trigger automated actions based on tag values\n- **Compliance**: Meet organizational and regulatory tagging requirements\n\n### Example\n\n```yaml\ntags:\n  - key: Environment\n    value: Production\n  - key: Project\n    value: WebApplication\n  - key: Owner\n    value: Platform-Team\n  - key: CostCenter\n    value: Engineering\n  - key: Backup\n    value: Daily\n```",
+      "properties": {
+        "key": {
+          "description": "**Tag Key** *(Required)*\n\nThe tag key name that identifies the type of metadata being stored. Tag keys should follow consistent naming conventions across your organization.",
+          "type": "string"
+        },
+        "value": {
+          "description": "**Tag Value** *(Required)*\n\nThe tag value that provides the actual metadata content for the tag key. Values should be meaningful and follow organizational standards.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "type": "object"
     },
     "NonEmptyString": {
       "description": "## Non-Empty String Type\n\nRepresents a string that must contain at least one character. Used for required text fields throughout the Landing Zone Accelerator configuration where empty values are not permitted.\n\n```",

--- a/source/packages/@aws-accelerator/constructs/index.ts
+++ b/source/packages/@aws-accelerator/constructs/index.ts
@@ -112,6 +112,7 @@ export * from './lib/aws-organizations/organizational-units';
 export * from './lib/aws-organizations/policy';
 export * from './lib/aws-organizations/policy-attachment';
 export * from './lib/aws-organizations/register-delegated-administrator';
+export * from './lib/aws-organizations/tag-account';
 export * from './lib/aws-organizations/validate-scp-count';
 export * from './lib/aws-ram/enable-sharing-with-aws-organization';
 export * from './lib/aws-ram/resource-share';

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account.ts
@@ -1,0 +1,92 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { CUSTOM_RESOURCE_PROVIDER_RUNTIME } from '@aws-accelerator/utils/lib/lambda';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as path from 'path';
+
+/**
+ * Account tag properties
+ */
+export interface AccountTagProps {
+  /**
+   * Account ID to tag
+   */
+  readonly accountId: string;
+  /**
+   * Tags to apply to the account
+   */
+  readonly tags: { [key: string]: string };
+  /**
+   * Custom resource lambda log group encryption key, when undefined default AWS managed key will be used
+   */
+  readonly kmsKey?: cdk.aws_kms.IKey;
+  /**
+   * Custom resource lambda log retention in days
+   */
+  readonly logRetentionInDays: number;
+}
+
+/**
+ * Class to manage AWS Organizations Account Tags
+ */
+export class AccountTag extends cdk.Resource {
+  constructor(scope: Construct, id: string, props: AccountTagProps) {
+    super(scope, id);
+
+    const ACCOUNT_TAG_TYPE = 'Custom::AccountTag';
+
+    const provider = cdk.CustomResourceProvider.getOrCreateProvider(this, ACCOUNT_TAG_TYPE, {
+      codeDirectory: path.join(__dirname, 'tag-account/dist'),
+      runtime: CUSTOM_RESOURCE_PROVIDER_RUNTIME,
+      policyStatements: [
+        {
+          Effect: 'Allow',
+          Action: [
+            'organizations:TagResource',
+            'organizations:UntagResource',
+            'organizations:ListTagsForResource',
+            'organizations:DescribeAccount',
+          ],
+          Resource: '*',
+        },
+      ],
+    });
+
+    new cdk.CustomResource(this, 'Resource', {
+      resourceType: ACCOUNT_TAG_TYPE,
+      serviceToken: provider.serviceToken,
+      properties: {
+        accountId: props.accountId,
+        tags: props.tags,
+        partition: cdk.Aws.PARTITION,
+      },
+    });
+
+    /**
+     * Singleton pattern to define the log group for the singleton function
+     * in the stack
+     */
+    const stack = cdk.Stack.of(scope);
+    const logGroup = stack.node.tryFindChild(`${provider.node.id}LogGroup`) as cdk.aws_logs.LogGroup;
+    if (!logGroup) {
+      new cdk.aws_logs.LogGroup(stack, `${provider.node.id}LogGroup`, {
+        logGroupName: `/aws/lambda/${(provider.node.findChild('Handler') as cdk.aws_lambda.Function).functionName}`,
+        retention: props.logRetentionInDays,
+        encryptionKey: props.kmsKey,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+    }
+  }
+}

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account.ts
@@ -64,7 +64,7 @@ export class AccountTag extends cdk.Resource {
       ],
     });
 
-    new cdk.CustomResource(this, 'Resource', {
+    const resource = new cdk.CustomResource(this, 'Resource', {
       resourceType: ACCOUNT_TAG_TYPE,
       serviceToken: provider.serviceToken,
       properties: {
@@ -79,14 +79,14 @@ export class AccountTag extends cdk.Resource {
      * in the stack
      */
     const stack = cdk.Stack.of(scope);
-    const logGroup = stack.node.tryFindChild(`${provider.node.id}LogGroup`) as cdk.aws_logs.LogGroup;
-    if (!logGroup) {
+    const logGroup =
+      (stack.node.tryFindChild(`${provider.node.id}LogGroup`) as cdk.aws_logs.LogGroup) ??
       new cdk.aws_logs.LogGroup(stack, `${provider.node.id}LogGroup`, {
-        logGroupName: `/aws/lambda/${(provider.node.findChild('Handler') as cdk.aws_lambda.Function).functionName}`,
+        logGroupName: `/aws/lambda/${(provider.node.findChild('Handler') as cdk.aws_lambda.CfnFunction).ref}`,
         retention: props.logRetentionInDays,
         encryptionKey: props.kmsKey,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
       });
-    }
+    resource.node.addDependency(logGroup);
   }
 }

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/index.ts
@@ -18,82 +18,58 @@
  * @returns
  */
 
+import { setOrganizationsClient } from '@aws-accelerator/utils/lib/set-organizations-client';
+import { throttlingBackOff } from '@aws-accelerator/utils/lib/throttle';
+import { CloudFormationCustomResourceEvent } from '@aws-accelerator/utils/lib/common-types';
 import {
   DescribeAccountCommand,
   ListTagsForResourceCommand,
   OrganizationsClient,
+  Tag,
   TagResourceCommand,
   UntagResourceCommand,
 } from '@aws-sdk/client-organizations';
 
-interface CloudFormationCustomResourceEvent {
-  RequestType: 'Create' | 'Update' | 'Delete';
-  ResponseURL: string;
-  StackId: string;
-  RequestId: string;
-  ResourceType: string;
-  LogicalResourceId: string;
-  ResourceProperties: {
-    accountId: string;
-    tags: { [key: string]: string };
-    partition?: string;
-  };
-  OldResourceProperties?: {
-    tags?: { [key: string]: string };
-  };
-}
-
-const solutionId = process.env['SOLUTION_ID'] ?? '';
-
-let organizationsClient: OrganizationsClient;
-
 export async function handler(event: CloudFormationCustomResourceEvent): Promise<
   | {
+      PhysicalResourceId: string | undefined;
       Status: string;
-      StatusReason?: string;
     }
   | undefined
 > {
   console.log(JSON.stringify(event, null, 2));
 
-  const partition = event.ResourceProperties.partition ?? 'aws';
-  const globalRegion = partition === 'aws' ? 'us-east-1' : 'us-gov-east-1';
+  const accountId: string = event.ResourceProperties['accountId'];
+  const partition: string = event.ResourceProperties['partition'];
+  const solutionId = process.env['SOLUTION_ID'];
 
-  organizationsClient = new OrganizationsClient({
-    region: globalRegion,
-    customUserAgent: solutionId,
-  });
+  // Organizations is a global service. The client is configured for the correct global region based on partition.
+  const organizationsClient = setOrganizationsClient(partition, solutionId);
 
-  const accountId = event.ResourceProperties.accountId;
-  const newTags: { [key: string]: string } = event.ResourceProperties.tags || {};
+  switch (event.RequestType) {
+    case 'Create':
+    case 'Update':
+      const newTags: { [key: string]: string } = event.ResourceProperties['tags'] ?? {};
+      const oldTags: { [key: string]: string } =
+        event.RequestType === 'Update' ? event.OldResourceProperties['tags'] ?? {} : {};
+      await manageAccountTags(organizationsClient, accountId, newTags, oldTags);
+      return {
+        PhysicalResourceId: `account-tag-${accountId}`,
+        Status: 'SUCCESS',
+      };
 
-  try {
-    switch (event.RequestType) {
-      case 'Create':
-      case 'Update':
-        const oldTags =
-          event.RequestType === 'Update' && event.OldResourceProperties ? event.OldResourceProperties.tags || {} : {};
-        await handleCreateOrUpdate(accountId, newTags, oldTags);
-        break;
-
-      case 'Delete':
-        await handleDelete(accountId);
-        break;
-    }
-
-    return {
-      Status: 'SUCCESS',
-    };
-  } catch (error) {
-    console.error('Error managing account tags:', error);
-    return {
-      Status: 'FAILED',
-      StatusReason: `Failed to manage account tags: ${error}`,
-    };
+    case 'Delete':
+      // We don't remove tags on delete as the account may continue to exist outside of the LZA
+      console.log(`Delete event - leaving account tags unchanged for account ${accountId}`);
+      return {
+        PhysicalResourceId: event.PhysicalResourceId,
+        Status: 'SUCCESS',
+      };
   }
 }
 
-async function handleCreateOrUpdate(
+async function manageAccountTags(
+  organizationsClient: OrganizationsClient,
   accountId: string,
   newTags: { [key: string]: string },
   oldTags: { [key: string]: string },
@@ -102,18 +78,18 @@ async function handleCreateOrUpdate(
   console.log(`New tags:`, newTags);
   console.log(`Old tags:`, oldTags);
 
-  // Verify account exists
+  // Verify account exists and is accessible
   try {
-    await organizationsClient.send(new DescribeAccountCommand({ AccountId: accountId }));
+    await throttlingBackOff(() => organizationsClient.send(new DescribeAccountCommand({ AccountId: accountId })));
   } catch (error) {
     throw new Error(`Account ${accountId} not found or not accessible: ${error}`);
   }
 
   // Get current tags from Organizations
-  const currentTags = await getCurrentAccountTags(accountId);
+  const currentTags = await getCurrentAccountTags(organizationsClient, accountId);
   console.log(`Current tags from Organizations:`, currentTags);
 
-  // Determine tags to add/update
+  // Determine tags to add/update (only where the value differs from what already exists)
   const tagsToApply: { [key: string]: string } = {};
   for (const [key, value] of Object.entries(newTags)) {
     if (currentTags[key] !== value) {
@@ -121,7 +97,7 @@ async function handleCreateOrUpdate(
     }
   }
 
-  // Determine tags to remove (tags that were in old config but not in new config)
+  // Determine tags to remove (previously configured tags that are no longer in the config)
   const tagsToRemove: string[] = [];
   for (const key of Object.keys(oldTags)) {
     if (!(key in newTags) && key in currentTags) {
@@ -132,13 +108,15 @@ async function handleCreateOrUpdate(
   // Apply new/updated tags
   if (Object.keys(tagsToApply).length > 0) {
     console.log(`Applying tags:`, tagsToApply);
-    const tags = Object.entries(tagsToApply).map(([key, value]) => ({ Key: key, Value: value }));
+    const tags: Tag[] = Object.entries(tagsToApply).map(([key, value]) => ({ Key: key, Value: value }));
 
-    await organizationsClient.send(
-      new TagResourceCommand({
-        ResourceId: accountId,
-        Tags: tags,
-      }),
+    await throttlingBackOff(() =>
+      organizationsClient.send(
+        new TagResourceCommand({
+          ResourceId: accountId,
+          Tags: tags,
+        }),
+      ),
     );
     console.log(`Successfully applied ${tags.length} tags to account ${accountId}`);
   }
@@ -146,11 +124,13 @@ async function handleCreateOrUpdate(
   // Remove tags that are no longer needed
   if (tagsToRemove.length > 0) {
     console.log(`Removing tags:`, tagsToRemove);
-    await organizationsClient.send(
-      new UntagResourceCommand({
-        ResourceId: accountId,
-        TagKeys: tagsToRemove,
-      }),
+    await throttlingBackOff(() =>
+      organizationsClient.send(
+        new UntagResourceCommand({
+          ResourceId: accountId,
+          TagKeys: tagsToRemove,
+        }),
+      ),
     );
     console.log(`Successfully removed ${tagsToRemove.length} tags from account ${accountId}`);
   }
@@ -160,29 +140,27 @@ async function handleCreateOrUpdate(
   }
 }
 
-async function handleDelete(accountId: string) {
-  console.log(`Delete event - leaving account tags unchanged for account ${accountId}`);
-  // We don't remove tags on delete as they may be managed by other resources
-  // or the account may continue to exist outside of the LZA
-}
-
-async function getCurrentAccountTags(accountId: string): Promise<{ [key: string]: string }> {
-  try {
-    const response = await organizationsClient.send(
-      new ListTagsForResourceCommand({
-        ResourceId: accountId,
-      }),
+async function getCurrentAccountTags(
+  organizationsClient: OrganizationsClient,
+  accountId: string,
+): Promise<{ [key: string]: string }> {
+  const tags: { [key: string]: string } = {};
+  let nextToken: string | undefined = undefined;
+  do {
+    const response = await throttlingBackOff(() =>
+      organizationsClient.send(
+        new ListTagsForResourceCommand({
+          ResourceId: accountId,
+          NextToken: nextToken,
+        }),
+      ),
     );
-
-    const tags: { [key: string]: string } = {};
-    for (const tag of response.Tags || []) {
+    for (const tag of response.Tags ?? []) {
       if (tag.Key && tag.Value !== undefined) {
         tags[tag.Key] = tag.Value;
       }
     }
-    return tags;
-  } catch (error) {
-    console.warn(`Could not retrieve tags for account ${accountId}:`, error);
-    return {};
-  }
+    nextToken = response.NextToken;
+  } while (nextToken);
+  return tags;
 }

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/index.ts
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/index.ts
@@ -1,0 +1,188 @@
+/**
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+/**
+ * aws-organizations-tag-account - lambda handler
+ *
+ * @param event
+ * @returns
+ */
+
+import {
+  DescribeAccountCommand,
+  ListTagsForResourceCommand,
+  OrganizationsClient,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-organizations';
+
+interface CloudFormationCustomResourceEvent {
+  RequestType: 'Create' | 'Update' | 'Delete';
+  ResponseURL: string;
+  StackId: string;
+  RequestId: string;
+  ResourceType: string;
+  LogicalResourceId: string;
+  ResourceProperties: {
+    accountId: string;
+    tags: { [key: string]: string };
+    partition?: string;
+  };
+  OldResourceProperties?: {
+    tags?: { [key: string]: string };
+  };
+}
+
+const solutionId = process.env['SOLUTION_ID'] ?? '';
+
+let organizationsClient: OrganizationsClient;
+
+export async function handler(event: CloudFormationCustomResourceEvent): Promise<
+  | {
+      Status: string;
+      StatusReason?: string;
+    }
+  | undefined
+> {
+  console.log(JSON.stringify(event, null, 2));
+
+  const partition = event.ResourceProperties.partition ?? 'aws';
+  const globalRegion = partition === 'aws' ? 'us-east-1' : 'us-gov-east-1';
+
+  organizationsClient = new OrganizationsClient({
+    region: globalRegion,
+    customUserAgent: solutionId,
+  });
+
+  const accountId = event.ResourceProperties.accountId;
+  const newTags: { [key: string]: string } = event.ResourceProperties.tags || {};
+
+  try {
+    switch (event.RequestType) {
+      case 'Create':
+      case 'Update':
+        const oldTags =
+          event.RequestType === 'Update' && event.OldResourceProperties ? event.OldResourceProperties.tags || {} : {};
+        await handleCreateOrUpdate(accountId, newTags, oldTags);
+        break;
+
+      case 'Delete':
+        await handleDelete(accountId);
+        break;
+    }
+
+    return {
+      Status: 'SUCCESS',
+    };
+  } catch (error) {
+    console.error('Error managing account tags:', error);
+    return {
+      Status: 'FAILED',
+      StatusReason: `Failed to manage account tags: ${error}`,
+    };
+  }
+}
+
+async function handleCreateOrUpdate(
+  accountId: string,
+  newTags: { [key: string]: string },
+  oldTags: { [key: string]: string },
+) {
+  console.log(`Managing tags for account ${accountId}`);
+  console.log(`New tags:`, newTags);
+  console.log(`Old tags:`, oldTags);
+
+  // Verify account exists
+  try {
+    await organizationsClient.send(new DescribeAccountCommand({ AccountId: accountId }));
+  } catch (error) {
+    throw new Error(`Account ${accountId} not found or not accessible: ${error}`);
+  }
+
+  // Get current tags from Organizations
+  const currentTags = await getCurrentAccountTags(accountId);
+  console.log(`Current tags from Organizations:`, currentTags);
+
+  // Determine tags to add/update
+  const tagsToApply: { [key: string]: string } = {};
+  for (const [key, value] of Object.entries(newTags)) {
+    if (currentTags[key] !== value) {
+      tagsToApply[key] = value;
+    }
+  }
+
+  // Determine tags to remove (tags that were in old config but not in new config)
+  const tagsToRemove: string[] = [];
+  for (const key of Object.keys(oldTags)) {
+    if (!(key in newTags) && key in currentTags) {
+      tagsToRemove.push(key);
+    }
+  }
+
+  // Apply new/updated tags
+  if (Object.keys(tagsToApply).length > 0) {
+    console.log(`Applying tags:`, tagsToApply);
+    const tags = Object.entries(tagsToApply).map(([key, value]) => ({ Key: key, Value: value }));
+
+    await organizationsClient.send(
+      new TagResourceCommand({
+        ResourceId: accountId,
+        Tags: tags,
+      }),
+    );
+    console.log(`Successfully applied ${tags.length} tags to account ${accountId}`);
+  }
+
+  // Remove tags that are no longer needed
+  if (tagsToRemove.length > 0) {
+    console.log(`Removing tags:`, tagsToRemove);
+    await organizationsClient.send(
+      new UntagResourceCommand({
+        ResourceId: accountId,
+        TagKeys: tagsToRemove,
+      }),
+    );
+    console.log(`Successfully removed ${tagsToRemove.length} tags from account ${accountId}`);
+  }
+
+  if (Object.keys(tagsToApply).length === 0 && tagsToRemove.length === 0) {
+    console.log(`No tag changes needed for account ${accountId}`);
+  }
+}
+
+async function handleDelete(accountId: string) {
+  console.log(`Delete event - leaving account tags unchanged for account ${accountId}`);
+  // We don't remove tags on delete as they may be managed by other resources
+  // or the account may continue to exist outside of the LZA
+}
+
+async function getCurrentAccountTags(accountId: string): Promise<{ [key: string]: string }> {
+  try {
+    const response = await organizationsClient.send(
+      new ListTagsForResourceCommand({
+        ResourceId: accountId,
+      }),
+    );
+
+    const tags: { [key: string]: string } = {};
+    for (const tag of response.Tags || []) {
+      if (tag.Key && tag.Value !== undefined) {
+        tags[tag.Key] = tag.Value;
+      }
+    }
+    return tags;
+  } catch (error) {
+    console.warn(`Could not retrieve tags for account ${accountId}:`, error);
+    return {};
+  }
+}

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/package.json
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/package.json
@@ -1,10 +1,41 @@
 {
   "name": "@aws-accelerator/constructs-aws-organizations-tag-account",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
+  "description": "Custom resource Lambda",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com/solutions"
+  },
   "main": "index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "esbuild --minify --bundle --sourcemap --platform=node --outfile=./dist/index.js index.ts",
+    "cleanup": "tsc --build ./ --clean && rm -rf node_modules && rm -rf dist && rm -rf cdk.out",
+    "cleanup:tsc": "tsc --build ./ --clean",
+    "lint": "eslint --fix  --max-warnings 0 -c ../../../../../../eslint.config.mjs '**/*.{ts,tsx}' --ignore-pattern \"*.d.ts\" ",
+    "precommit": "eslint --max-warnings 0 -c ../../../../../../eslint.config.mjs '**/*.{ts,tsx}' --ignore-pattern \"*.d.ts\" ",
+    "test": "vitest run --coverage --passWithNoTests",
+    "testreport": "",
+    "build-prod": "esbuild --minify --bundle --platform=node --outfile=./dist/index.js index.ts"
+  },
   "dependencies": {
-    "@aws-accelerator/utils": "*",
-    "@aws-sdk/client-organizations": "^3.0.0"
+    "@aws-accelerator/utils": "^0.0.0",
+    "@aws-sdk/client-organizations": "3.1041.0"
+  },
+  "devDependencies": {
+    "@types/node": "18.19.50",
+    "esbuild": "0.25.0",
+    "eslint": "9.37.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-import-resolver-typescript": "4.4.4",
+    "eslint-plugin-import": "2.32.0",
+    "eslint-plugin-license-header": "0.8.0",
+    "eslint-plugin-prettier": "5.5.4",
+    "prettier": "3.6.2",
+    "vitest": "4.1.8",
+    "ts-node": "10.9.1",
+    "typescript": "5.8.3"
   }
 }

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/package.json
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@aws-accelerator/constructs-aws-organizations-tag-account",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "dependencies": {
+    "@aws-accelerator/utils": "*",
+    "@aws-sdk/client-organizations": "^3.0.0"
+  }
+}

--- a/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/tsconfig.json
+++ b/source/packages/@aws-accelerator/constructs/lib/aws-organizations/tag-account/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["index.ts"],
+  "exclude": ["test/**/*"]
+}


### PR DESCRIPTION
## Description

Adds support for tagging AWS accounts directly from `accounts-config.yaml`. Previously there was no way to manage AWS Organizations account tags through LZA — tags defined in configuration were never applied or updated.

## Changes

- **Config model & schema**: Added optional `tags: ITag[]` to `IAccountConfig` and `IGovCloudAccountConfig` (and the corresponding config classes and JSON schema).
- **New construct**: `AccountTag` (`@aws-accelerator/constructs`) — a custom resource that manages account tags via the AWS Organizations API.
- **New custom-resource Lambda**: `aws-organizations/tag-account` — compares current vs. desired tags and applies additions/updates and removals (`TagResource`/`UntagResource`), with `ListTagsForResource` pagination and throttling backoff.
- **Integration**: `OrganizationsStack` creates an `AccountTag` for each account that defines `tags`, executed in the home region only (consistent with other global Organizations operations, and correct for external pipeline account deployments).

## Usage

```yaml
workloadAccounts:
  - name: Production
    email: production@example.com
    organizationalUnit: Workloads
    tags:
      - key: Environment
        value: Production
      - key: CostCenter
        value: Engineering
```

Changing tags in config updates them on the account; removing a previously-configured tag removes it from the account.

## Testing

Validated end-to-end in a live LZA deployment (management account, home region `ap-southeast-2`):

- Installer + accelerator pipelines complete successfully; the `organizations` stage synthesizes and deploys.
- `OrganizationsStack` provisions `Custom::AccountTag` resources (all `CREATE_COMPLETE`) plus the provider Lambda and role.
- Verified real account tags applied via the Organizations API, with distinct per-account values driven by config, e.g.:
  - `XXX`: `sca:inspector=ec2+ecr`, `sca:hz-delegation=richard`, `usage=developer`
  - `YYYYY`: `sca:hz-delegation=shared-services`, `usage=shared-services`

## Notes

- Only accounts with `tags` defined get an `AccountTag` resource; existing configurations are unaffected.
- Tag operations run from the management account (which holds Organizations permissions), so this works with external/qualifier-based pipeline account deployments.
